### PR TITLE
feat: ServerStateKey provide an object internally

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -47,7 +47,7 @@ daxus
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:3](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L3)
+[adapters/paginationAdapter.ts:3](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L3)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[hooks/types.ts:61](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L61)
+[hooks/types.ts:61](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L61)
 
 ## Functions
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[contexts/AccessorOptionsContext.tsx:14](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/contexts/AccessorOptionsContext.tsx#L14)
+[contexts/AccessorOptionsContext.tsx:14](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/contexts/AccessorOptionsContext.tsx#L14)
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 #### Defined in
 
-[contexts/ServerStateKeyContext.tsx:15](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/contexts/ServerStateKeyContext.tsx#L15)
+[contexts/ServerStateKeyContext.tsx:14](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/contexts/ServerStateKeyContext.tsx#L14)
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 #### Defined in
 
-[model/Model.ts:18](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Model.ts#L18)
+[model/Model.ts:18](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Model.ts#L18)
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:130](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L130)
+[adapters/paginationAdapter.ts:130](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L130)
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:18](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/useAccessor.ts#L18)
+[hooks/useAccessor.ts:18](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/useAccessor.ts#L18)
 
 ▸ **useAccessor**<`S`, `Arg`, `RD`, `SS`, `E`\>(`accessor`, `getSnapshot`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`NormalAccessor`](classes/NormalAccessor.md)<`S`, `Arg`, `RD`, `E`\> \| ``null``\>
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:29](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/useAccessor.ts#L29)
+[hooks/useAccessor.ts:29](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/useAccessor.ts#L29)
 
 ▸ **useAccessor**<`S`, `Arg`, `RD`, `SS`, `E`\>(`accessor`, `getSnapshot`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`S`, `Arg`, `RD`, `E`\>\>
 
@@ -272,7 +272,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:40](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/useAccessor.ts#L40)
+[hooks/useAccessor.ts:40](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/useAccessor.ts#L40)
 
 ▸ **useAccessor**<`S`, `Arg`, `RD`, `SS`, `E`\>(`accessor`, `getSnapshot`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`S`, `Arg`, `RD`, `E`\> \| ``null``\>
 
@@ -302,7 +302,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:51](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/useAccessor.ts#L51)
+[hooks/useAccessor.ts:51](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/useAccessor.ts#L51)
 
 ___
 
@@ -332,18 +332,18 @@ You can use it for server side render.
 
 #### Defined in
 
-[hooks/useHydrate.ts:12](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/useHydrate.ts#L12)
+[hooks/useHydrate.ts:12](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/useHydrate.ts#L12)
 
 ___
 
 ### useServerStateKeyContext
 
-▸ **useServerStateKeyContext**(): `undefined` \| `object`
+▸ **useServerStateKeyContext**(): `object`
 
 #### Returns
 
-`undefined` \| `object`
+`object`
 
 #### Defined in
 
-[contexts/ServerStateKeyContext.tsx:11](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/contexts/ServerStateKeyContext.tsx#L11)
+[contexts/ServerStateKeyContext.tsx:10](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/contexts/ServerStateKeyContext.tsx#L10)

--- a/docs/api/classes/Accessor.md
+++ b/docs/api/classes/Accessor.md
@@ -53,7 +53,7 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:42](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Accessor.ts#L42)
+[model/Accessor.ts:42](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Accessor.ts#L42)
 
 ___
 
@@ -73,7 +73,7 @@ Return the result of the revalidation. It may be `null` if the revalidation is a
 
 #### Defined in
 
-[model/Accessor.ts:37](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Accessor.ts#L37)
+[model/Accessor.ts:37](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Accessor.ts#L37)
 
 ## Methods
 
@@ -87,4 +87,4 @@ Return the result of the revalidation. It may be `null` if the revalidation is a
 
 #### Defined in
 
-[model/Accessor.ts:126](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Accessor.ts#L126)
+[model/Accessor.ts:126](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Accessor.ts#L126)

--- a/docs/api/classes/InfiniteAccessor.md
+++ b/docs/api/classes/InfiniteAccessor.md
@@ -57,7 +57,7 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:42](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Accessor.ts#L42)
+[model/Accessor.ts:42](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Accessor.ts#L42)
 
 ## Methods
 
@@ -75,7 +75,7 @@ The all pages if it is not interrupted by the other revalidation, otherwise retu
 
 #### Defined in
 
-[model/InfiniteAccessor.ts:58](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/InfiniteAccessor.ts#L58)
+[model/InfiniteAccessor.ts:58](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/InfiniteAccessor.ts#L58)
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 #### Defined in
 
-[model/Accessor.ts:126](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Accessor.ts#L126)
+[model/Accessor.ts:126](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Accessor.ts#L126)
 
 ___
 
@@ -115,4 +115,4 @@ Accessor.revalidate
 
 #### Defined in
 
-[model/InfiniteAccessor.ts:49](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/InfiniteAccessor.ts#L49)
+[model/InfiniteAccessor.ts:49](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/InfiniteAccessor.ts#L49)

--- a/docs/api/classes/NormalAccessor.md
+++ b/docs/api/classes/NormalAccessor.md
@@ -56,7 +56,7 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:42](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Accessor.ts#L42)
+[model/Accessor.ts:42](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Accessor.ts#L42)
 
 ## Methods
 
@@ -74,7 +74,7 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:126](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Accessor.ts#L126)
+[model/Accessor.ts:126](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Accessor.ts#L126)
 
 ___
 
@@ -96,4 +96,4 @@ Accessor.revalidate
 
 #### Defined in
 
-[model/NormalAccessor.ts:40](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/NormalAccessor.ts#L40)
+[model/NormalAccessor.ts:40](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/NormalAccessor.ts#L40)

--- a/docs/api/interfaces/AccessorOptions.md
+++ b/docs/api/interfaces/AccessorOptions.md
@@ -51,7 +51,7 @@ A function to determine whether the returned data from the `getSnapshot` functio
 
 #### Defined in
 
-[hooks/types.ts:31](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L31)
+[hooks/types.ts:31](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L31)
 
 ___
 
@@ -67,7 +67,7 @@ The time span in milliseconds to deduplicate requests with the same accessor.
 
 #### Defined in
 
-[hooks/types.ts:46](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L46)
+[hooks/types.ts:46](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L46)
 
 ___
 
@@ -83,7 +83,7 @@ Return the previous data until the new data has been fetched.
 
 #### Defined in
 
-[hooks/types.ts:56](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L56)
+[hooks/types.ts:56](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L56)
 
 ___
 
@@ -99,7 +99,7 @@ The interval in milliseconds for polling data. If the value is less than or equa
 
 #### Defined in
 
-[hooks/types.ts:51](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L51)
+[hooks/types.ts:51](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L51)
 
 ___
 
@@ -115,7 +115,7 @@ The number of retry attempts for errors.
 
 #### Defined in
 
-[hooks/types.ts:36](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L36)
+[hooks/types.ts:36](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L36)
 
 ___
 
@@ -131,7 +131,7 @@ The interval in milliseconds between retry attempts for errors.
 
 #### Defined in
 
-[hooks/types.ts:41](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L41)
+[hooks/types.ts:41](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L41)
 
 ___
 
@@ -147,7 +147,7 @@ Whether it should revalidate when the accessor is stale.
 
 #### Defined in
 
-[hooks/types.ts:26](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L26)
+[hooks/types.ts:26](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L26)
 
 ___
 
@@ -163,7 +163,7 @@ Whether the accessor should revalidate data when the user refocuses the page.
 
 #### Defined in
 
-[hooks/types.ts:11](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L11)
+[hooks/types.ts:11](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L11)
 
 ___
 
@@ -179,7 +179,7 @@ Whether it should revalidate when the `accessor` changes.
 
 #### Defined in
 
-[hooks/types.ts:21](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L21)
+[hooks/types.ts:21](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L21)
 
 ___
 
@@ -195,4 +195,4 @@ Whether the accessor should revalidate data when the user reconnects to the netw
 
 #### Defined in
 
-[hooks/types.ts:16](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/hooks/types.ts#L16)
+[hooks/types.ts:16](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/hooks/types.ts#L16)

--- a/docs/api/interfaces/AccessorOptionsProviderProps.md
+++ b/docs/api/interfaces/AccessorOptionsProviderProps.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[contexts/AccessorOptionsContext.tsx:11](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/contexts/AccessorOptionsContext.tsx#L11)
+[contexts/AccessorOptionsContext.tsx:11](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/contexts/AccessorOptionsContext.tsx#L11)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[contexts/AccessorOptionsContext.tsx:10](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/contexts/AccessorOptionsContext.tsx#L10)
+[contexts/AccessorOptionsContext.tsx:10](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/contexts/AccessorOptionsContext.tsx#L10)

--- a/docs/api/interfaces/InfiniteAccessorCreator.md
+++ b/docs/api/interfaces/InfiniteAccessorCreator.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[model/Model.ts:15](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Model.ts#L15)
+[model/Model.ts:15](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Model.ts#L15)
 
 ## Table of contents
 
@@ -59,4 +59,4 @@ BaseAccessorCreator.invalidate
 
 #### Defined in
 
-[model/Model.ts:9](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Model.ts#L9)
+[model/Model.ts:9](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Model.ts#L9)

--- a/docs/api/interfaces/InfiniteAction.md
+++ b/docs/api/interfaces/InfiniteAction.md
@@ -51,7 +51,7 @@
 
 #### Defined in
 
-[model/types.ts:23](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L23)
+[model/types.ts:23](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L23)
 
 ___
 
@@ -81,7 +81,7 @@ BaseAction.onError
 
 #### Defined in
 
-[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L4)
+[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L4)
 
 ___
 
@@ -111,7 +111,7 @@ BaseAction.onSuccess
 
 #### Defined in
 
-[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L5)
+[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L5)
 
 ___
 
@@ -140,4 +140,4 @@ ___
 
 #### Defined in
 
-[model/types.ts:27](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L27)
+[model/types.ts:27](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L27)

--- a/docs/api/interfaces/NormalAccessorCreator.md
+++ b/docs/api/interfaces/NormalAccessorCreator.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[model/Model.ts:12](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Model.ts#L12)
+[model/Model.ts:12](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Model.ts#L12)
 
 ## Table of contents
 
@@ -59,4 +59,4 @@ BaseAccessorCreator.invalidate
 
 #### Defined in
 
-[model/Model.ts:9](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/Model.ts#L9)
+[model/Model.ts:9](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/Model.ts#L9)

--- a/docs/api/interfaces/NormalAction.md
+++ b/docs/api/interfaces/NormalAction.md
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[model/types.ts:10](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L10)
+[model/types.ts:10](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L10)
 
 ___
 
@@ -78,7 +78,7 @@ BaseAction.onError
 
 #### Defined in
 
-[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L4)
+[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L4)
 
 ___
 
@@ -108,7 +108,7 @@ BaseAction.onSuccess
 
 #### Defined in
 
-[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L5)
+[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L5)
 
 ___
 
@@ -136,4 +136,4 @@ ___
 
 #### Defined in
 
-[model/types.ts:11](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/model/types.ts#L11)
+[model/types.ts:11](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/model/types.ts#L11)

--- a/docs/api/interfaces/Pagination.md
+++ b/docs/api/interfaces/Pagination.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:12](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L12)
+[adapters/paginationAdapter.ts:12](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L12)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:13](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L13)
+[adapters/paginationAdapter.ts:13](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L13)

--- a/docs/api/interfaces/PaginationAdapter.md
+++ b/docs/api/interfaces/PaginationAdapter.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:22](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L22)
+[adapters/paginationAdapter.ts:22](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L22)
 
 ## Methods
 
@@ -68,7 +68,7 @@ Append the data to the pagination. If the pagination is not existed, create one.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:93](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L93)
+[adapters/paginationAdapter.ts:93](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L93)
 
 ___
 
@@ -91,7 +91,7 @@ Add the data to the state.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:26](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L26)
+[adapters/paginationAdapter.ts:26](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L26)
 
 ___
 
@@ -114,7 +114,7 @@ Delete the entity with the specified id and remove the data from pagination (if 
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:49](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L49)
+[adapters/paginationAdapter.ts:49](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L49)
 
 ___
 
@@ -138,7 +138,7 @@ Prepend the data to the pagination. If the pagination is not existed, create one
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:97](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L97)
+[adapters/paginationAdapter.ts:97](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L97)
 
 ___
 
@@ -162,7 +162,7 @@ This function is useful when you are sure that the data is existed.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:41](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L41)
+[adapters/paginationAdapter.ts:41](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L41)
 
 ___
 
@@ -186,7 +186,7 @@ It is useful when you are sure that the pagination is existed.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:85](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L85)
+[adapters/paginationAdapter.ts:85](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L85)
 
 ___
 
@@ -210,7 +210,7 @@ It is useful when you are sure that the pagination is existed.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:69](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L69)
+[adapters/paginationAdapter.ts:69](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L69)
 
 ___
 
@@ -234,7 +234,7 @@ Replace the whole pagination with the given data array.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:89](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L89)
+[adapters/paginationAdapter.ts:89](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L89)
 
 ___
 
@@ -258,7 +258,7 @@ Set the `noMore` property in the pagination meta.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:101](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L101)
+[adapters/paginationAdapter.ts:101](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L101)
 
 ___
 
@@ -282,7 +282,7 @@ Sort the pagination by the `compare` function.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:105](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L105)
+[adapters/paginationAdapter.ts:105](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L105)
 
 ___
 
@@ -306,7 +306,7 @@ If it is not existed, return `undefined`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:31](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L31)
+[adapters/paginationAdapter.ts:31](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L31)
 
 ___
 
@@ -344,7 +344,7 @@ It is useful when you are using `useAccessor`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:36](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L36)
+[adapters/paginationAdapter.ts:36](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L36)
 
 ___
 
@@ -367,7 +367,7 @@ Try to read the pagination with the specified key. If it is not existed, return 
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:73](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L73)
+[adapters/paginationAdapter.ts:73](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L73)
 
 ___
 
@@ -405,7 +405,7 @@ If is useful when using `useAccessor`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:78](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L78)
+[adapters/paginationAdapter.ts:78](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L78)
 
 ___
 
@@ -428,7 +428,7 @@ Try to read the pagination meta. If the meta is not existed, return `undefined`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:57](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L57)
+[adapters/paginationAdapter.ts:57](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L57)
 
 ___
 
@@ -466,7 +466,7 @@ It is useful when using `useAccessor`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:62](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L62)
+[adapters/paginationAdapter.ts:62](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L62)
 
 ___
 
@@ -490,7 +490,7 @@ Update the entity with the new data. If the entity is not existed, do nothing.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:45](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L45)
+[adapters/paginationAdapter.ts:45](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L45)
 
 ___
 
@@ -513,4 +513,4 @@ Update the entity with the data. If the entity is not existed, insert it to the 
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:53](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L53)
+[adapters/paginationAdapter.ts:53](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L53)

--- a/docs/api/interfaces/PaginationMeta.md
+++ b/docs/api/interfaces/PaginationMeta.md
@@ -19,7 +19,7 @@ Store the ids for each page index.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:7](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L7)
+[adapters/paginationAdapter.ts:7](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L7)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:8](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L8)
+[adapters/paginationAdapter.ts:8](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L8)

--- a/docs/api/interfaces/PaginationState.md
+++ b/docs/api/interfaces/PaginationState.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:17](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L17)
+[adapters/paginationAdapter.ts:17](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L17)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:18](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/adapters/paginationAdapter.ts#L18)
+[adapters/paginationAdapter.ts:18](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/adapters/paginationAdapter.ts#L18)

--- a/docs/api/interfaces/ServerStateKeyProviderProps.md
+++ b/docs/api/interfaces/ServerStateKeyProviderProps.md
@@ -7,7 +7,6 @@
 ### Properties
 
 - [children](ServerStateKeyProviderProps.md#children)
-- [value](ServerStateKeyProviderProps.md#value)
 
 ## Properties
 
@@ -17,14 +16,4 @@
 
 #### Defined in
 
-[contexts/ServerStateKeyContext.tsx:8](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/contexts/ServerStateKeyContext.tsx#L8)
-
-___
-
-### value
-
-• **value**: `object`
-
-#### Defined in
-
-[contexts/ServerStateKeyContext.tsx:7](https://github.com/jason89521/react-fetch/blob/1011800/src/lib/contexts/ServerStateKeyContext.tsx#L7)
+[contexts/ServerStateKeyContext.tsx:7](https://github.com/jason89521/react-fetch/blob/9f24fa5/src/lib/contexts/ServerStateKeyContext.tsx#L7)

--- a/src/lib/contexts/ServerStateKeyContext.tsx
+++ b/src/lib/contexts/ServerStateKeyContext.tsx
@@ -1,10 +1,9 @@
 import type { ReactNode } from 'react';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
-const serverStateKeyContext = createContext<object | undefined>(undefined);
+const serverStateKeyContext = createContext<object>({});
 
 export interface ServerStateKeyProviderProps {
-  value: object;
   children: ReactNode;
 }
 
@@ -12,6 +11,8 @@ export function useServerStateKeyContext() {
   return useContext(serverStateKeyContext);
 }
 
-export function ServerStateKeyProvider({ value, children }: ServerStateKeyProviderProps) {
+export function ServerStateKeyProvider({ children }: ServerStateKeyProviderProps) {
+  const value = useMemo(() => ({}), []);
+
   return <serverStateKeyContext.Provider value={value}>{children}</serverStateKeyContext.Provider>;
 }


### PR DESCRIPTION
## Proposed change

Developers now do not need to pass server state key.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Testing
- [ ] Refactor
- [ ] Chore (tool changes, configuration changes, and changes to things that do not actually go into production at all)

## Implementation

## Related Issue
