### PR TITLE
fix: notify lazy accessor itself only

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -34,10 +34,13 @@ daxus
 
 - [AccessorOptionsProvider](README.md#accessoroptionsprovider)
 - [ServerStateKeyProvider](README.md#serverstatekeyprovider)
+- [createLazyModel](README.md#createlazymodel)
 - [createModel](README.md#createmodel)
 - [createPaginationAdapter](README.md#createpaginationadapter)
 - [useAccessor](README.md#useaccessor)
 - [useHydrate](README.md#usehydrate)
+- [useLazyAccessor](README.md#uselazyaccessor)
+- [useModel](README.md#usemodel)
 - [useServerStateKeyContext](README.md#useserverstatekeycontext)
 
 ## Type Aliases
@@ -55,7 +58,7 @@ daxus
 
 #### Defined in
 
-[model/Accessor.ts:13](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L13)
+[model/Accessor.ts:12](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L12)
 
 ___
 
@@ -65,7 +68,7 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:3](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L3)
+[adapters/paginationAdapter.ts:3](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L3)
 
 ___
 
@@ -93,7 +96,7 @@ ___
 
 #### Defined in
 
-[hooks/types.ts:61](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L61)
+[hooks/types.ts:61](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L61)
 
 ## Functions
 
@@ -113,7 +116,7 @@ ___
 
 #### Defined in
 
-[contexts/AccessorOptionsContext.tsx:14](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/contexts/AccessorOptionsContext.tsx#L14)
+[contexts/AccessorOptionsContext.tsx:14](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/contexts/AccessorOptionsContext.tsx#L14)
 
 ___
 
@@ -133,13 +136,27 @@ ___
 
 #### Defined in
 
-[contexts/ServerStateKeyContext.tsx:14](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/contexts/ServerStateKeyContext.tsx#L14)
+[contexts/ServerStateKeyContext.tsx:14](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/contexts/ServerStateKeyContext.tsx#L14)
+
+___
+
+### createLazyModel
+
+▸ **createLazyModel**(): `LazyModel`
+
+#### Returns
+
+`LazyModel`
+
+#### Defined in
+
+[model/Model.ts:277](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Model.ts#L277)
 
 ___
 
 ### createModel
 
-▸ **createModel**<`S`\>(`initialState`): `Object`
+▸ **createModel**<`S`\>(`initialState`): `Model`<`S`\>
 
 #### Type parameters
 
@@ -155,19 +172,11 @@ ___
 
 #### Returns
 
-`Object`
-
-| Name | Type |
-| :------ | :------ |
-| `defineInfiniteAccessor` | <Arg, Data, E\>(`action`: [`InfiniteAction`](interfaces/InfiniteAction.md)<`S`, `Arg`, `Data`, `E`\>) => [`InfiniteAccessorCreator`](interfaces/InfiniteAccessorCreator.md)<`S`, `Arg`, `Data`, `E`\> |
-| `defineNormalAccessor` | <Arg, Data, E\>(`action`: [`NormalAction`](interfaces/NormalAction.md)<`S`, `Arg`, `Data`, `E`\>) => [`NormalAccessorCreator`](interfaces/NormalAccessorCreator.md)<`S`, `Arg`, `Data`, `E`\> |
-| `getState` | (`serverStateKey?`: `object`) => `S` |
-| `invalidate` | () => `void` |
-| `mutate` | (`fn`: (`draft`: `Draft`<`S`\>) => `void`, `serverStateKey?`: `object`) => `void` |
+`Model`<`S`\>
 
 #### Defined in
 
-[model/Model.ts:18](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Model.ts#L18)
+[model/Model.ts:76](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Model.ts#L76)
 
 ___
 
@@ -196,7 +205,7 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:130](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L130)
+[adapters/paginationAdapter.ts:130](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L130)
 
 ___
 
@@ -230,7 +239,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:18](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/useAccessor.ts#L18)
+[hooks/useAccessor.ts:18](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useAccessor.ts#L18)
 
 ▸ **useAccessor**<`S`, `Arg`, `RD`, `SS`, `E`\>(`accessor`, `getSnapshot`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`NormalAccessor`](classes/NormalAccessor.md)<`S`, `Arg`, `RD`, `E`\> \| ``null``\>
 
@@ -260,7 +269,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:29](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/useAccessor.ts#L29)
+[hooks/useAccessor.ts:29](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useAccessor.ts#L29)
 
 ▸ **useAccessor**<`S`, `Arg`, `RD`, `SS`, `E`\>(`accessor`, `getSnapshot`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`S`, `Arg`, `RD`, `E`\>\>
 
@@ -290,7 +299,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:40](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/useAccessor.ts#L40)
+[hooks/useAccessor.ts:40](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useAccessor.ts#L40)
 
 ▸ **useAccessor**<`S`, `Arg`, `RD`, `SS`, `E`\>(`accessor`, `getSnapshot`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`S`, `Arg`, `RD`, `E`\> \| ``null``\>
 
@@ -320,7 +329,7 @@ ___
 
 #### Defined in
 
-[hooks/useAccessor.ts:51](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/useAccessor.ts#L51)
+[hooks/useAccessor.ts:51](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useAccessor.ts#L51)
 
 ___
 
@@ -350,7 +359,151 @@ You can use it for server side render.
 
 #### Defined in
 
-[hooks/useHydrate.ts:11](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/useHydrate.ts#L11)
+[hooks/useHydrate.ts:11](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useHydrate.ts#L11)
+
+___
+
+### useLazyAccessor
+
+▸ **useLazyAccessor**<`Arg`, `Data`, `E`, `SS`\>(`accessor`, `getSnapshot?`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`NormalAccessor`](classes/NormalAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arg` | `Arg` |
+| `Data` | `Data` |
+| `E` | `E` |
+| `SS` | `undefined` \| `Data` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `accessor` | [`NormalAccessor`](classes/NormalAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> |
+| `getSnapshot?` | (`data`: `undefined` \| `Data`) => `SS` |
+| `options?` | [`AccessorOptions`](interfaces/AccessorOptions.md)<`SS`\> |
+
+#### Returns
+
+[`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`NormalAccessor`](classes/NormalAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\>\>
+
+#### Defined in
+
+[hooks/useLazyAccessor.ts:8](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useLazyAccessor.ts#L8)
+
+▸ **useLazyAccessor**<`Arg`, `Data`, `E`, `SS`\>(`accessor`, `getSnapshot?`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`NormalAccessor`](classes/NormalAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> \| ``null``\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arg` | `Arg` |
+| `Data` | `Data` |
+| `E` | `E` |
+| `SS` | `undefined` \| `Data` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `accessor` | ``null`` \| [`NormalAccessor`](classes/NormalAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> |
+| `getSnapshot?` | (`data`: `undefined` \| `Data`) => `SS` |
+| `options?` | [`AccessorOptions`](interfaces/AccessorOptions.md)<`SS`\> |
+
+#### Returns
+
+[`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`NormalAccessor`](classes/NormalAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> \| ``null``\>
+
+#### Defined in
+
+[hooks/useLazyAccessor.ts:13](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useLazyAccessor.ts#L13)
+
+▸ **useLazyAccessor**<`Arg`, `Data`, `E`, `SS`\>(`accessor`, `getSnapshot?`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arg` | `Arg` |
+| `Data` | `Data` |
+| `E` | `E` |
+| `SS` | `undefined` \| `Data`[] |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `accessor` | [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> |
+| `getSnapshot?` | (`data`: `undefined`[] \| `Data`) => `SS` |
+| `options?` | [`AccessorOptions`](interfaces/AccessorOptions.md)<`SS`\> |
+
+#### Returns
+
+[`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\>\>
+
+#### Defined in
+
+[hooks/useLazyAccessor.ts:18](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useLazyAccessor.ts#L18)
+
+▸ **useLazyAccessor**<`Arg`, `Data`, `E`, `SS`\>(`accessor`, `getSnapshot?`, `options?`): [`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> \| ``null``\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arg` | `Arg` |
+| `Data` | `Data` |
+| `E` | `E` |
+| `SS` | `undefined` \| `Data`[] |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `accessor` | ``null`` \| [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> |
+| `getSnapshot?` | (`data`: `undefined`[] \| `Data`) => `SS` |
+| `options?` | [`AccessorOptions`](interfaces/AccessorOptions.md)<`SS`\> |
+
+#### Returns
+
+[`UseAccessorReturn`](README.md#useaccessorreturn)<`SS` \| `undefined`, `E`, [`InfiniteAccessor`](classes/InfiniteAccessor.md)<`LazyState`, `Arg`, `Data`, `E`\> \| ``null``\>
+
+#### Defined in
+
+[hooks/useLazyAccessor.ts:23](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useLazyAccessor.ts#L23)
+
+___
+
+### useModel
+
+▸ **useModel**<`S`, `SS`\>(`model`, `getSnapshot`): `SS`
+
+This hook is useful when you only want to subscribe the state of a model, but don't want to use any accessor to trigger a request.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `S` | extends `object` |
+| `SS` | `SS` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `model` | `Model`<`S`\> | The model you want to subscribe |
+| `getSnapshot` | (`state`: `S`) => `SS` | Return the data you want whenever the state of the model changes. Make sure that this function is wrapped by `useCallback`. Otherwise it would cause unnecessary rerender. |
+
+#### Returns
+
+`SS`
+
+The return value of the `getSnapshot` function.
+
+#### Defined in
+
+[hooks/useModel.ts:15](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/useModel.ts#L15)
 
 ___
 
@@ -364,4 +517,4 @@ ___
 
 #### Defined in
 
-[contexts/ServerStateKeyContext.tsx:10](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/contexts/ServerStateKeyContext.tsx#L10)
+[contexts/ServerStateKeyContext.tsx:10](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/contexts/ServerStateKeyContext.tsx#L10)

--- a/docs/api/classes/Accessor.md
+++ b/docs/api/classes/Accessor.md
@@ -1,14 +1,15 @@
 [daxus](../README.md) / Accessor
 
-# Class: Accessor<S, D, E\>
+# Class: Accessor<S, D, E, Arg\>
 
 ## Type parameters
 
-| Name |
-| :------ |
-| `S` |
-| `D` |
-| `E` |
+| Name | Type |
+| :------ | :------ |
+| `S` | `S` |
+| `D` | `D` |
+| `E` | `E` |
+| `Arg` | `unknown` |
 
 ## Hierarchy
 
@@ -27,7 +28,9 @@
 
 ### Methods
 
+- [getKey](Accessor.md#getkey)
 - [invalidate](Accessor.md#invalidate)
+- [subscribeData](Accessor.md#subscribedata)
 
 ## Properties
 
@@ -53,7 +56,7 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:44](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L44)
+[model/Accessor.ts:50](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L50)
 
 ___
 
@@ -73,9 +76,23 @@ Return the result of the revalidation.
 
 #### Defined in
 
-[model/Accessor.ts:39](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L39)
+[model/Accessor.ts:45](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L45)
 
 ## Methods
+
+### getKey
+
+▸ **getKey**(): `string`
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[model/Accessor.ts:85](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L85)
+
+___
 
 ### invalidate
 
@@ -87,4 +104,30 @@ Return the result of the revalidation.
 
 #### Defined in
 
-[model/Accessor.ts:128](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L128)
+[model/Accessor.ts:160](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L160)
+
+___
+
+### subscribeData
+
+▸ **subscribeData**(`listener`): () => `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `listener` | () => `void` |
+
+#### Returns
+
+`fn`
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[model/Accessor.ts:140](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L140)

--- a/docs/api/classes/InfiniteAccessor.md
+++ b/docs/api/classes/InfiniteAccessor.md
@@ -13,7 +13,7 @@
 
 ## Hierarchy
 
-- [`Accessor`](Accessor.md)<`S`, `Data`[], `E`\>
+- [`Accessor`](Accessor.md)<`S`, `Data`[], `E`, `Arg`\>
 
   ↳ **`InfiniteAccessor`**
 
@@ -26,8 +26,10 @@
 ### Methods
 
 - [fetchNext](InfiniteAccessor.md#fetchnext)
+- [getKey](InfiniteAccessor.md#getkey)
 - [invalidate](InfiniteAccessor.md#invalidate)
 - [revalidate](InfiniteAccessor.md#revalidate)
+- [subscribeData](InfiniteAccessor.md#subscribedata)
 
 ## Properties
 
@@ -57,7 +59,7 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:44](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L44)
+[model/Accessor.ts:50](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L50)
 
 ## Methods
 
@@ -75,7 +77,25 @@ The all pages if it is not interrupted by the other revalidation, otherwise retu
 
 #### Defined in
 
-[model/InfiniteAccessor.ts:57](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/InfiniteAccessor.ts#L57)
+[model/InfiniteAccessor.ts:67](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/InfiniteAccessor.ts#L67)
+
+___
+
+### getKey
+
+▸ **getKey**(): `string`
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+[Accessor](Accessor.md).[getKey](Accessor.md#getkey)
+
+#### Defined in
+
+[model/Accessor.ts:85](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L85)
 
 ___
 
@@ -93,7 +113,7 @@ ___
 
 #### Defined in
 
-[model/Accessor.ts:128](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L128)
+[model/Accessor.ts:160](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L160)
 
 ___
 
@@ -113,4 +133,34 @@ Accessor.revalidate
 
 #### Defined in
 
-[model/InfiniteAccessor.ts:48](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/InfiniteAccessor.ts#L48)
+[model/InfiniteAccessor.ts:58](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/InfiniteAccessor.ts#L58)
+
+___
+
+### subscribeData
+
+▸ **subscribeData**(`listener`): () => `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `listener` | () => `void` |
+
+#### Returns
+
+`fn`
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[Accessor](Accessor.md).[subscribeData](Accessor.md#subscribedata)
+
+#### Defined in
+
+[model/Accessor.ts:140](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L140)

--- a/docs/api/classes/NormalAccessor.md
+++ b/docs/api/classes/NormalAccessor.md
@@ -13,7 +13,7 @@
 
 ## Hierarchy
 
-- [`Accessor`](Accessor.md)<`S`, `Data`, `E`\>
+- [`Accessor`](Accessor.md)<`S`, `Data`, `E`, `Arg`\>
 
   ↳ **`NormalAccessor`**
 
@@ -25,8 +25,10 @@
 
 ### Methods
 
+- [getKey](NormalAccessor.md#getkey)
 - [invalidate](NormalAccessor.md#invalidate)
 - [revalidate](NormalAccessor.md#revalidate)
+- [subscribeData](NormalAccessor.md#subscribedata)
 
 ## Properties
 
@@ -56,9 +58,27 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:44](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L44)
+[model/Accessor.ts:50](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L50)
 
 ## Methods
+
+### getKey
+
+▸ **getKey**(): `string`
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+[Accessor](Accessor.md).[getKey](Accessor.md#getkey)
+
+#### Defined in
+
+[model/Accessor.ts:85](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L85)
+
+___
 
 ### invalidate
 
@@ -74,7 +94,7 @@ Get the state of the corresponding model.
 
 #### Defined in
 
-[model/Accessor.ts:128](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Accessor.ts#L128)
+[model/Accessor.ts:160](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L160)
 
 ___
 
@@ -94,4 +114,34 @@ Accessor.revalidate
 
 #### Defined in
 
-[model/NormalAccessor.ts:39](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/NormalAccessor.ts#L39)
+[model/NormalAccessor.ts:44](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/NormalAccessor.ts#L44)
+
+___
+
+### subscribeData
+
+▸ **subscribeData**(`listener`): () => `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `listener` | () => `void` |
+
+#### Returns
+
+`fn`
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[Accessor](Accessor.md).[subscribeData](Accessor.md#subscribedata)
+
+#### Defined in
+
+[model/Accessor.ts:140](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Accessor.ts#L140)

--- a/docs/api/interfaces/AccessorOptions.md
+++ b/docs/api/interfaces/AccessorOptions.md
@@ -51,7 +51,7 @@ A function to determine whether the returned data from the `getSnapshot` functio
 
 #### Defined in
 
-[hooks/types.ts:31](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L31)
+[hooks/types.ts:31](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L31)
 
 ___
 
@@ -67,7 +67,7 @@ The time span in milliseconds to deduplicate requests with the same accessor.
 
 #### Defined in
 
-[hooks/types.ts:46](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L46)
+[hooks/types.ts:46](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L46)
 
 ___
 
@@ -83,7 +83,7 @@ Return the previous data until the new data has been fetched.
 
 #### Defined in
 
-[hooks/types.ts:56](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L56)
+[hooks/types.ts:56](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L56)
 
 ___
 
@@ -99,7 +99,7 @@ The interval in milliseconds for polling data. If the value is less than or equa
 
 #### Defined in
 
-[hooks/types.ts:51](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L51)
+[hooks/types.ts:51](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L51)
 
 ___
 
@@ -115,7 +115,7 @@ The number of retry attempts for errors.
 
 #### Defined in
 
-[hooks/types.ts:36](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L36)
+[hooks/types.ts:36](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L36)
 
 ___
 
@@ -131,7 +131,7 @@ The interval in milliseconds between retry attempts for errors.
 
 #### Defined in
 
-[hooks/types.ts:41](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L41)
+[hooks/types.ts:41](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L41)
 
 ___
 
@@ -147,7 +147,7 @@ Whether it should revalidate when the accessor is stale.
 
 #### Defined in
 
-[hooks/types.ts:26](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L26)
+[hooks/types.ts:26](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L26)
 
 ___
 
@@ -163,7 +163,7 @@ Whether the accessor should revalidate data when the user refocuses the page.
 
 #### Defined in
 
-[hooks/types.ts:11](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L11)
+[hooks/types.ts:11](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L11)
 
 ___
 
@@ -179,7 +179,7 @@ Whether it should revalidate when the `accessor` changes.
 
 #### Defined in
 
-[hooks/types.ts:21](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L21)
+[hooks/types.ts:21](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L21)
 
 ___
 
@@ -195,4 +195,4 @@ Whether the accessor should revalidate data when the user reconnects to the netw
 
 #### Defined in
 
-[hooks/types.ts:16](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/hooks/types.ts#L16)
+[hooks/types.ts:16](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/hooks/types.ts#L16)

--- a/docs/api/interfaces/AccessorOptionsProviderProps.md
+++ b/docs/api/interfaces/AccessorOptionsProviderProps.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[contexts/AccessorOptionsContext.tsx:11](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/contexts/AccessorOptionsContext.tsx#L11)
+[contexts/AccessorOptionsContext.tsx:11](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/contexts/AccessorOptionsContext.tsx#L11)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[contexts/AccessorOptionsContext.tsx:10](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/contexts/AccessorOptionsContext.tsx#L10)
+[contexts/AccessorOptionsContext.tsx:10](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/contexts/AccessorOptionsContext.tsx#L10)

--- a/docs/api/interfaces/InfiniteAccessorCreator.md
+++ b/docs/api/interfaces/InfiniteAccessorCreator.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[model/Model.ts:15](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Model.ts#L15)
+[model/Model.ts:36](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Model.ts#L36)
 
 ## Table of contents
 
@@ -59,4 +59,4 @@ BaseAccessorCreator.invalidate
 
 #### Defined in
 
-[model/Model.ts:9](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Model.ts#L9)
+[model/Model.ts:17](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Model.ts#L17)

--- a/docs/api/interfaces/InfiniteAction.md
+++ b/docs/api/interfaces/InfiniteAction.md
@@ -51,7 +51,7 @@
 
 #### Defined in
 
-[model/types.ts:23](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L23)
+[model/types.ts:31](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L31)
 
 ___
 
@@ -81,7 +81,7 @@ BaseAction.onError
 
 #### Defined in
 
-[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L4)
+[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L4)
 
 ___
 
@@ -111,7 +111,7 @@ BaseAction.onSuccess
 
 #### Defined in
 
-[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L5)
+[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L5)
 
 ___
 
@@ -140,4 +140,4 @@ ___
 
 #### Defined in
 
-[model/types.ts:27](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L27)
+[model/types.ts:35](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L35)

--- a/docs/api/interfaces/NormalAccessorCreator.md
+++ b/docs/api/interfaces/NormalAccessorCreator.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[model/Model.ts:12](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Model.ts#L12)
+[model/Model.ts:33](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Model.ts#L33)
 
 ## Table of contents
 
@@ -59,4 +59,4 @@ BaseAccessorCreator.invalidate
 
 #### Defined in
 
-[model/Model.ts:9](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/Model.ts#L9)
+[model/Model.ts:17](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/Model.ts#L17)

--- a/docs/api/interfaces/NormalAction.md
+++ b/docs/api/interfaces/NormalAction.md
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[model/types.ts:10](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L10)
+[model/types.ts:18](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L18)
 
 ___
 
@@ -78,7 +78,7 @@ BaseAction.onError
 
 #### Defined in
 
-[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L4)
+[model/types.ts:4](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L4)
 
 ___
 
@@ -108,7 +108,7 @@ BaseAction.onSuccess
 
 #### Defined in
 
-[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L5)
+[model/types.ts:5](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L5)
 
 ___
 
@@ -136,4 +136,4 @@ ___
 
 #### Defined in
 
-[model/types.ts:11](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/model/types.ts#L11)
+[model/types.ts:19](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/model/types.ts#L19)

--- a/docs/api/interfaces/Pagination.md
+++ b/docs/api/interfaces/Pagination.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:12](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L12)
+[adapters/paginationAdapter.ts:12](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L12)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:13](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L13)
+[adapters/paginationAdapter.ts:13](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L13)

--- a/docs/api/interfaces/PaginationAdapter.md
+++ b/docs/api/interfaces/PaginationAdapter.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:22](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L22)
+[adapters/paginationAdapter.ts:22](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L22)
 
 ## Methods
 
@@ -68,7 +68,7 @@ Append the data to the pagination. If the pagination does not exist, create one.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:93](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L93)
+[adapters/paginationAdapter.ts:93](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L93)
 
 ___
 
@@ -91,7 +91,7 @@ Add the data to the state.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:26](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L26)
+[adapters/paginationAdapter.ts:26](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L26)
 
 ___
 
@@ -114,7 +114,7 @@ Delete the entity with the specified id and remove the data from pagination (if 
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:49](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L49)
+[adapters/paginationAdapter.ts:49](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L49)
 
 ___
 
@@ -138,7 +138,7 @@ Prepend the data to the pagination. If the pagination does not exist, create one
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:97](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L97)
+[adapters/paginationAdapter.ts:97](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L97)
 
 ___
 
@@ -162,7 +162,7 @@ This function is useful when you are sure that the data is existed.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:41](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L41)
+[adapters/paginationAdapter.ts:41](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L41)
 
 ___
 
@@ -186,7 +186,7 @@ It is useful when you are sure that the pagination is existed.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:85](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L85)
+[adapters/paginationAdapter.ts:85](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L85)
 
 ___
 
@@ -210,7 +210,7 @@ It is useful when you are sure that the pagination is existed.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:69](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L69)
+[adapters/paginationAdapter.ts:69](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L69)
 
 ___
 
@@ -234,7 +234,7 @@ Replace the whole pagination with the given data array.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:89](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L89)
+[adapters/paginationAdapter.ts:89](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L89)
 
 ___
 
@@ -258,7 +258,7 @@ Set the `noMore` property in the pagination meta.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:101](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L101)
+[adapters/paginationAdapter.ts:101](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L101)
 
 ___
 
@@ -282,7 +282,7 @@ Sort the pagination by the `compare` function.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:105](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L105)
+[adapters/paginationAdapter.ts:105](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L105)
 
 ___
 
@@ -306,7 +306,7 @@ If it does not exist, return `undefined`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:31](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L31)
+[adapters/paginationAdapter.ts:31](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L31)
 
 ___
 
@@ -344,7 +344,7 @@ It is useful when you are using `useAccessor`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:36](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L36)
+[adapters/paginationAdapter.ts:36](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L36)
 
 ___
 
@@ -367,7 +367,7 @@ Try to read the pagination with the specified key. If it does not exist, return 
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:73](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L73)
+[adapters/paginationAdapter.ts:73](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L73)
 
 ___
 
@@ -405,7 +405,7 @@ If is useful when using `useAccessor`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:78](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L78)
+[adapters/paginationAdapter.ts:78](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L78)
 
 ___
 
@@ -428,7 +428,7 @@ Try to read the pagination meta. If the meta does not exist, return `undefined`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:57](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L57)
+[adapters/paginationAdapter.ts:57](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L57)
 
 ___
 
@@ -466,7 +466,7 @@ It is useful when using `useAccessor`.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:62](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L62)
+[adapters/paginationAdapter.ts:62](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L62)
 
 ___
 
@@ -490,7 +490,7 @@ Update the entity with the new data. If the entity does not exist, do nothing.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:45](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L45)
+[adapters/paginationAdapter.ts:45](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L45)
 
 ___
 
@@ -513,4 +513,4 @@ Update the entity with the data. If the entity does not exist, insert it to the 
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:53](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L53)
+[adapters/paginationAdapter.ts:53](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L53)

--- a/docs/api/interfaces/PaginationMeta.md
+++ b/docs/api/interfaces/PaginationMeta.md
@@ -19,7 +19,7 @@ Store the ids for each page index.
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:7](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L7)
+[adapters/paginationAdapter.ts:7](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L7)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:8](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L8)
+[adapters/paginationAdapter.ts:8](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L8)

--- a/docs/api/interfaces/PaginationState.md
+++ b/docs/api/interfaces/PaginationState.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:17](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L17)
+[adapters/paginationAdapter.ts:17](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L17)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[adapters/paginationAdapter.ts:18](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/adapters/paginationAdapter.ts#L18)
+[adapters/paginationAdapter.ts:18](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/adapters/paginationAdapter.ts#L18)

--- a/docs/api/interfaces/ServerStateKeyProviderProps.md
+++ b/docs/api/interfaces/ServerStateKeyProviderProps.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[contexts/ServerStateKeyContext.tsx:7](https://github.com/jason89521/react-fetch/blob/6ec4382/src/lib/contexts/ServerStateKeyContext.tsx#L7)
+[contexts/ServerStateKeyContext.tsx:7](https://github.com/jason89521/react-fetch/blob/6f430a6/src/lib/contexts/ServerStateKeyContext.tsx#L7)

--- a/src/lib/model/InfiniteAccessor.ts
+++ b/src/lib/model/InfiniteAccessor.ts
@@ -21,7 +21,6 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Acc
    */
   private rejectFetching: (() => void) | null = null;
   private currentTask: Task = 'idle';
-  private notifyModel: () => void;
   private initialPageNum: number;
 
   /**
@@ -38,11 +37,11 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Acc
     onUnmount,
     prefix,
     initialPageNum,
+    isLazy,
   }: InfiniteConstructorArgs<S, Arg, Data, E>) {
-    super({ getState, modelSubscribe, onMount, onUnmount, arg, prefix });
+    super({ getState, modelSubscribe, onMount, onUnmount, arg, prefix, notifyModel, isLazy });
     this.action = action;
     this.updateState = updateState;
-    this.notifyModel = notifyModel;
     this.initialPageNum = initialPageNum;
   }
 
@@ -73,7 +72,7 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Acc
 
   private updateData = (data: Data[]) => {
     this.data = data;
-    this.notifyModel();
+    this.notifyDataListeners();
   };
 
   /**

--- a/src/lib/model/Model.ts
+++ b/src/lib/model/Model.ts
@@ -164,6 +164,7 @@ export function createModel<S extends object>(initialState: S): Model<S> {
         onMount,
         onUnmount,
         prefix,
+        isLazy: action.isLazy ?? false,
       };
 
       if (isServer()) {
@@ -233,6 +234,7 @@ export function createModel<S extends object>(initialState: S): Model<S> {
         onUnmount,
         prefix,
         initialPageNum: infiniteAccessorPageNumRecord[key] ?? 1,
+        isLazy: action.isLazy ?? false,
       };
 
       if (isServer()) {
@@ -280,11 +282,12 @@ export function createLazyModel(): LazyModel {
     const prefix = prefixCounter++;
     return model.defineNormalAccessor({
       ...action,
+      prefix,
+      isLazy: true,
       syncState(draft, { data, arg }) {
         const key = getKey(prefix, arg);
         draft[key] = data;
       },
-      prefix,
     });
   }
 
@@ -295,6 +298,7 @@ export function createLazyModel(): LazyModel {
     return model.defineInfiniteAccessor({
       ...action,
       prefix,
+      isLazy: true,
       syncState(draft, { pageIndex, data, arg }) {
         const key = getKey(prefix, arg);
         if (pageIndex === 0) {

--- a/src/lib/model/NormalAccessor.ts
+++ b/src/lib/model/NormalAccessor.ts
@@ -16,7 +16,6 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
 > {
   private action: NormalAction<S, Arg, Data, E>;
   private updateState: (cb: (draft: Draft<S>) => void) => void;
-  private notifyModel: () => void;
 
   /**
    * @internal
@@ -31,12 +30,12 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
     onMount,
     onUnmount,
     prefix,
+    isLazy,
   }: NormalConstructorArgs<S, Arg, Data, E>) {
-    super({ getState, modelSubscribe, onMount, onUnmount, arg, prefix });
+    super({ getState, modelSubscribe, onMount, onUnmount, arg, prefix, notifyModel, isLazy });
     this.action = action;
     this.arg = arg;
     this.updateState = updateState;
-    this.notifyModel = notifyModel;
   }
 
   /**
@@ -70,7 +69,7 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
           this.updateStatus({ error });
           this.action.onError?.({ error: error!, arg });
         }
-        this.notifyModel();
+        this.notifyDataListeners();
         this.onFetchingFinish();
         if (error) return [error] as const;
         if (data) return [null, data] as const;

--- a/src/lib/model/types.ts
+++ b/src/lib/model/types.ts
@@ -7,6 +7,10 @@ interface BaseAction<Arg, D, E> {
    * @internal
    */
   prefix?: number;
+  /**
+   * @internal
+   */
+  isLazy?: boolean;
 }
 
 export interface NormalAction<S, Arg = any, Data = any, E = unknown>
@@ -49,6 +53,7 @@ export interface BaseConstructorArgs<S, Arg> {
   onMount: () => void;
   onUnmount: () => void;
   prefix: number;
+  isLazy: boolean;
 }
 
 export interface NormalConstructorArgs<S, Arg, Data, E> extends BaseConstructorArgs<S, Arg> {


### PR DESCRIPTION
## Proposed change

close #157 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Testing
- [ ] Refactor
- [ ] Chore (tool changes, configuration changes, and changes to things that do not actually go into production at all)

## Implementation

## Related Issue
