### PR TITLE
feat: add useSuspenseAccessor

### DIFF
--- a/src/__tests__/useSuspenseAccessor.test.tsx
+++ b/src/__tests__/useSuspenseAccessor.test.tsx
@@ -1,0 +1,88 @@
+import { Suspense, useState } from 'react';
+import { useSuspenseAccessor } from '../lib/index.js';
+import { createControl, createPostModel, renderWithOptionsProvider } from './utils.js';
+import { fireEvent } from '@testing-library/react';
+import { isUndefined } from '../lib/utils/isUndefined.js';
+
+describe('useSuspenseAccessor-normal', () => {
+  test('should show the data when fetching finish', async () => {
+    const control = createControl({});
+    const { getPostById, postAdapter } = createPostModel(control);
+    function Post() {
+      const { data } = useSuspenseAccessor(getPostById(0), postAdapter.tryReadOneFactory(0));
+
+      return <div>{data.title}</div>;
+    }
+    function Page() {
+      return (
+        <Suspense fallback="loading">
+          <Post />
+        </Suspense>
+      );
+    }
+
+    const { getByText, findByText } = renderWithOptionsProvider(<Page />);
+    getByText('loading');
+    await findByText('title0');
+  });
+
+  test('should work when accessor changes', async () => {
+    const control = createControl({});
+    const { getPostById, postAdapter } = createPostModel(control);
+    function Post({ id }: { id: number }) {
+      const { data } = useSuspenseAccessor(getPostById(id), postAdapter.tryReadOneFactory(id));
+
+      return <div>{data.title}</div>;
+    }
+    function Page() {
+      const [id, setId] = useState(0);
+
+      return (
+        <>
+          <button onClick={() => setId(id + 1)}>next</button>
+          <Suspense fallback="loading">
+            <Post id={id} />
+          </Suspense>
+        </>
+      );
+    }
+
+    const { getByText, findByText } = renderWithOptionsProvider(<Page />);
+    getByText('loading');
+    await findByText('title0');
+
+    fireEvent.click(getByText('next'));
+    getByText('loading');
+    await findByText('title1');
+  });
+
+  test('should work with conditional fetching', async () => {
+    const control = createControl({});
+    const { getPostById, postAdapter } = createPostModel(control);
+    function Post({ id }: { id: number | undefined }) {
+      const { data } = useSuspenseAccessor(
+        isUndefined(id) ? null : getPostById(id),
+        postAdapter.tryReadOneFactory(id!)
+      );
+
+      return <div>{data?.title}</div>;
+    }
+    function Page() {
+      const [id, setId] = useState<number | undefined>();
+
+      return (
+        <>
+          <button onClick={() => setId(0)}>next</button>
+          <Suspense fallback="loading">
+            <Post id={id} />
+          </Suspense>
+        </>
+      );
+    }
+
+    const { getByText, findByText } = renderWithOptionsProvider(<Page />);
+    getByText('loading');
+    fireEvent.click(getByText('next'));
+    await findByText('title0');
+  });
+});

--- a/src/__tests__/useSuspenseAccessor.test.tsx
+++ b/src/__tests__/useSuspenseAccessor.test.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState } from 'react';
-import { useSuspenseAccessor } from '../lib/index.js';
+import { createAutoModel, useSuspenseAccessor } from '../lib/index.js';
 import { createControl, createPostModel, renderWithOptionsProvider } from './utils.js';
 import { fireEvent } from '@testing-library/react';
 import { isUndefined } from '../lib/utils/isUndefined.js';
@@ -84,5 +84,69 @@ describe('useSuspenseAccessor-normal', () => {
     getByText('loading');
     fireEvent.click(getByText('next'));
     await findByText('title0');
+  });
+});
+
+describe('useSuspenseAccessor-auto state', () => {
+  let model = createAutoModel();
+
+  beforeEach(() => {
+    model = createAutoModel();
+  });
+
+  test('should show the data when fetching finish', async () => {
+    const getData = model.defineNormalAccessor({
+      async fetchData() {
+        return 'data';
+      },
+    });
+
+    function Data() {
+      const { data } = useSuspenseAccessor(getData());
+
+      return <div>{data}</div>;
+    }
+    function Page() {
+      return (
+        <Suspense fallback="loading">
+          <Data />
+        </Suspense>
+      );
+    }
+
+    const { getByText, findByText } = renderWithOptionsProvider(<Page />);
+    getByText('loading');
+    await findByText('data');
+  });
+
+  test('should update the data when the corresponding cache is updated', async () => {
+    let counter = 0;
+    const getData = model.defineNormalAccessor({
+      async fetchData() {
+        counter += 1;
+        return counter;
+      },
+    });
+    function Data() {
+      const { data } = useSuspenseAccessor(getData());
+
+      return <div>{data}</div>;
+    }
+    function Page() {
+      return (
+        <>
+          <button onClick={() => getData().revalidate()}>revalidate</button>
+          <Suspense fallback="loading">
+            <Data />
+          </Suspense>
+        </>
+      );
+    }
+
+    const { getByText, findByText } = renderWithOptionsProvider(<Page />);
+    getByText('loading');
+    await findByText('1');
+    fireEvent.click(getByText('revalidate'));
+    await findByText('2');
   });
 });

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useAccessor.js';
 export * from './useHydrate.js';
 export * from './useModel.js';
+export * from './useSuspenseAccessor.js';

--- a/src/lib/hooks/useAccessor.ts
+++ b/src/lib/hooks/useAccessor.ts
@@ -208,7 +208,7 @@ export function useAccessor<S, D, SS, E = unknown>(
   };
 }
 
-function normalizeArgs<S, D, SS, E>(
+export function normalizeArgs<S, D, SS, E>(
   accessor: Accessor<S, any, D, E> | null,
   maybeGetSnapshot: ((state: S) => SS) | AutoAccessorOptions<D, SS> = {},
   accessorOptions: AccessorOptions<SS> = {}

--- a/src/lib/hooks/useSuspenseAccessor.ts
+++ b/src/lib/hooks/useSuspenseAccessor.ts
@@ -64,8 +64,13 @@ export function useSuspenseAccessor<S, D, SS, E = unknown>(
   const [, options] = normalizeArgs(accessor, maybeGetSnapshot, accessorOptions);
   const defaultOptions = useContext(accessorOptionsContext);
   const { checkHasData } = { ...defaultOptions, ...options };
-  const { data } = useAccessor(accessor as any, maybeGetSnapshot as any, accessorOptions) as {
+  const { data, error } = useAccessor(
+    accessor as any,
+    maybeGetSnapshot as any,
+    accessorOptions
+  ) as {
     data: SS;
+    error: E;
   };
 
   if (!accessor) throw new Promise(noop);
@@ -78,6 +83,10 @@ export function useSuspenseAccessor<S, D, SS, E = unknown>(
     } else {
       throw accessor.revalidate();
     }
+  }
+
+  if (error && !hasData) {
+    throw error;
   }
 
   return {

--- a/src/lib/hooks/useSuspenseAccessor.ts
+++ b/src/lib/hooks/useSuspenseAccessor.ts
@@ -3,10 +3,9 @@ import type { NormalAccessor, InfiniteAccessor, AutoState, Accessor } from '../m
 
 import { normalizeArgs, useAccessor } from './useAccessor.js';
 import { accessorOptionsContext } from '../contexts/AccessorOptionsContext.js';
-import { useContext, useMemo, useSyncExternalStore } from 'react';
+import { useContext } from 'react';
 import type { NonUndefined } from '../utils/index.js';
-import { isNonUndefined, isUndefined, noop, stableHash } from '../utils/index.js';
-import { useServerStateKeyContext } from '../index.js';
+import { isNonUndefined, isUndefined, noop } from '../utils/index.js';
 
 interface ReturnValue<S, ACC extends Accessor<any, any, any, any> | null> {
   data: S;

--- a/src/lib/hooks/useSuspenseAccessor.ts
+++ b/src/lib/hooks/useSuspenseAccessor.ts
@@ -73,7 +73,7 @@ export function useSuspenseAccessor<S, D, SS, E = unknown>(
     error: E;
   };
 
-  if (!accessor) throw new Promise(noop);
+  if (!accessor) throw Promise.resolve()
 
   const hasData = !isUndefined(data) ? checkHasData(data) : false;
 

--- a/src/lib/hooks/useSuspenseAccessor.ts
+++ b/src/lib/hooks/useSuspenseAccessor.ts
@@ -5,7 +5,7 @@ import { normalizeArgs, useAccessor } from './useAccessor.js';
 import { accessorOptionsContext } from '../contexts/AccessorOptionsContext.js';
 import { useContext } from 'react';
 import type { NonUndefined } from '../utils/index.js';
-import { isNonUndefined, isUndefined, noop } from '../utils/index.js';
+import { isNonUndefined, isUndefined } from '../utils/index.js';
 
 interface ReturnValue<S, ACC extends Accessor<any, any, any, any> | null> {
   data: S;
@@ -73,13 +73,13 @@ export function useSuspenseAccessor<S, D, SS, E = unknown>(
     error: E;
   };
 
-  if (!accessor) throw Promise.resolve()
+  if (!accessor) throw Promise.resolve();
 
   const hasData = !isUndefined(data) ? checkHasData(data) : false;
 
   if (!hasData || !isNonUndefined(data)) {
     if (accessor.getStatus().isFetching) {
-      throw new Promise(noop);
+      throw Promise.resolve();
     } else {
       throw accessor.revalidate();
     }

--- a/src/lib/hooks/useSuspenseAccessor.ts
+++ b/src/lib/hooks/useSuspenseAccessor.ts
@@ -1,0 +1,86 @@
+import type { AccessorOptions, AutoAccessorOptions } from './types.js';
+import type { NormalAccessor, InfiniteAccessor, AutoState, Accessor } from '../model/index.js';
+
+import { normalizeArgs } from './useAccessor.js';
+import { accessorOptionsContext } from '../contexts/AccessorOptionsContext.js';
+import { useContext } from 'react';
+import { noop } from '../utils/noop.js';
+
+interface ReturnValue<S, ACC extends Accessor<any, any, any, any> | null> {
+  data: S;
+  accessor: ACC;
+}
+
+export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
+  accessor: NormalAccessor<S, Arg, RD, E>,
+  getSnapshot: (state: S) => SS,
+  options?: AccessorOptions<SS>
+): ReturnValue<NonNullable<SS>, NormalAccessor<S, Arg, RD, E>>;
+
+export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
+  accessor: NormalAccessor<S, Arg, RD, E> | null,
+  getSnapshot: (state: S) => SS,
+  options?: AccessorOptions<SS>
+): ReturnValue<SS, NormalAccessor<S, Arg, RD, E>>;
+
+export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
+  accessor: InfiniteAccessor<S, Arg, RD, E>,
+  getSnapshot: (state: S) => SS,
+  options?: AccessorOptions<SS>
+): ReturnValue<NonNullable<SS>, InfiniteAccessor<S, Arg, RD, E>>;
+
+export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
+  accessor: InfiniteAccessor<S, Arg, RD, E> | null,
+  getSnapshot: (state: S) => SS,
+  options?: AccessorOptions<SS>
+): ReturnValue<SS, InfiniteAccessor<S, Arg, RD, E>>;
+
+export function useSuspenseAccessor<Arg, D, E, SS = D | undefined>(
+  accessor: NormalAccessor<AutoState, Arg, D, E>,
+  options?: AutoAccessorOptions<D, SS>
+): ReturnValue<NonNullable<SS>, NormalAccessor<AutoState, Arg, D, E>>;
+
+export function useSuspenseAccessor<Arg, D, E, SS = D | undefined>(
+  accessor: NormalAccessor<AutoState, Arg, D, E> | null,
+  options?: AutoAccessorOptions<D, SS>
+): ReturnValue<SS, NormalAccessor<AutoState, Arg, D, E>>;
+
+export function useSuspenseAccessor<Arg, D, E, SS = D[] | undefined>(
+  accessor: InfiniteAccessor<AutoState, Arg, D, E>,
+  options?: AutoAccessorOptions<D[], SS>
+): ReturnValue<NonNullable<SS>, InfiniteAccessor<AutoState, Arg, D, E>>;
+
+export function useSuspenseAccessor<Arg, D, E, SS = D[] | undefined>(
+  accessor: InfiniteAccessor<AutoState, Arg, D, E> | null,
+  options?: AutoAccessorOptions<D[], SS>
+): ReturnValue<SS, InfiniteAccessor<AutoState, Arg, D, E>>;
+
+export function useSuspenseAccessor<S, D, SS, E = unknown>(
+  accessor: Accessor<S, any, D, E> | null,
+  maybeGetSnapshot: ((state: S) => SS) | AutoAccessorOptions<D, SS> = {},
+  accessorOptions: AccessorOptions<SS> = {}
+): ReturnValue<NonNullable<SS>, Accessor<S, any, D, E>> {
+  const [getSnapshot, options] = normalizeArgs(accessor, maybeGetSnapshot, accessorOptions);
+  const defaultOptions = useContext(accessorOptionsContext);
+  const requiredOptions = { ...defaultOptions, ...options };
+  const { checkHasData } = requiredOptions;
+
+  if (!accessor) throw new Promise(noop);
+
+  const state = accessor.getState();
+  const snapshot = getSnapshot(state);
+  const hasData = checkHasData(snapshot);
+
+  if (!hasData) {
+    if (accessor.getStatus().isFetching) {
+      throw new Promise(noop);
+    } else {
+      throw accessor.revalidate();
+    }
+  }
+
+  return {
+    data: snapshot as NonNullable<SS>,
+    accessor,
+  };
+}

--- a/src/lib/hooks/useSuspenseAccessor.ts
+++ b/src/lib/hooks/useSuspenseAccessor.ts
@@ -3,8 +3,10 @@ import type { NormalAccessor, InfiniteAccessor, AutoState, Accessor } from '../m
 
 import { normalizeArgs } from './useAccessor.js';
 import { accessorOptionsContext } from '../contexts/AccessorOptionsContext.js';
-import { useContext } from 'react';
-import { noop } from '../utils/noop.js';
+import { useContext, useMemo, useSyncExternalStore } from 'react';
+import type { NonUndefined } from '../utils/index.js';
+import { isNonUndefined, isUndefined, noop, stableHash } from '../utils/index.js';
+import { useServerStateKeyContext } from '../index.js';
 
 interface ReturnValue<S, ACC extends Accessor<any, any, any, any> | null> {
   data: S;
@@ -15,63 +17,85 @@ export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
   accessor: NormalAccessor<S, Arg, RD, E>,
   getSnapshot: (state: S) => SS,
   options?: AccessorOptions<SS>
-): ReturnValue<NonNullable<SS>, NormalAccessor<S, Arg, RD, E>>;
+): ReturnValue<NonUndefined<SS>, NormalAccessor<S, Arg, RD, E>>;
 
 export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
   accessor: NormalAccessor<S, Arg, RD, E> | null,
   getSnapshot: (state: S) => SS,
   options?: AccessorOptions<SS>
-): ReturnValue<SS, NormalAccessor<S, Arg, RD, E>>;
+): ReturnValue<NonUndefined<SS>, NormalAccessor<S, Arg, RD, E>>;
 
 export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
   accessor: InfiniteAccessor<S, Arg, RD, E>,
   getSnapshot: (state: S) => SS,
   options?: AccessorOptions<SS>
-): ReturnValue<NonNullable<SS>, InfiniteAccessor<S, Arg, RD, E>>;
+): ReturnValue<NonUndefined<SS>, InfiniteAccessor<S, Arg, RD, E>>;
 
 export function useSuspenseAccessor<S, Arg, RD, SS, E = unknown>(
   accessor: InfiniteAccessor<S, Arg, RD, E> | null,
   getSnapshot: (state: S) => SS,
   options?: AccessorOptions<SS>
-): ReturnValue<SS, InfiniteAccessor<S, Arg, RD, E>>;
+): ReturnValue<NonUndefined<SS>, InfiniteAccessor<S, Arg, RD, E>>;
 
 export function useSuspenseAccessor<Arg, D, E, SS = D | undefined>(
   accessor: NormalAccessor<AutoState, Arg, D, E>,
   options?: AutoAccessorOptions<D, SS>
-): ReturnValue<NonNullable<SS>, NormalAccessor<AutoState, Arg, D, E>>;
+): ReturnValue<NonUndefined<SS>, NormalAccessor<AutoState, Arg, D, E>>;
 
 export function useSuspenseAccessor<Arg, D, E, SS = D | undefined>(
   accessor: NormalAccessor<AutoState, Arg, D, E> | null,
   options?: AutoAccessorOptions<D, SS>
-): ReturnValue<SS, NormalAccessor<AutoState, Arg, D, E>>;
+): ReturnValue<NonUndefined<SS>, NormalAccessor<AutoState, Arg, D, E>>;
 
 export function useSuspenseAccessor<Arg, D, E, SS = D[] | undefined>(
   accessor: InfiniteAccessor<AutoState, Arg, D, E>,
   options?: AutoAccessorOptions<D[], SS>
-): ReturnValue<NonNullable<SS>, InfiniteAccessor<AutoState, Arg, D, E>>;
+): ReturnValue<NonUndefined<SS>, InfiniteAccessor<AutoState, Arg, D, E>>;
 
 export function useSuspenseAccessor<Arg, D, E, SS = D[] | undefined>(
   accessor: InfiniteAccessor<AutoState, Arg, D, E> | null,
   options?: AutoAccessorOptions<D[], SS>
-): ReturnValue<SS, InfiniteAccessor<AutoState, Arg, D, E>>;
+): ReturnValue<NonUndefined<SS>, InfiniteAccessor<AutoState, Arg, D, E>>;
 
 export function useSuspenseAccessor<S, D, SS, E = unknown>(
   accessor: Accessor<S, any, D, E> | null,
   maybeGetSnapshot: ((state: S) => SS) | AutoAccessorOptions<D, SS> = {},
   accessorOptions: AccessorOptions<SS> = {}
-): ReturnValue<NonNullable<SS>, Accessor<S, any, D, E>> {
+): ReturnValue<NonUndefined<SS>, Accessor<S, any, D, E>> {
+  const serverStateKey = useServerStateKeyContext();
   const [getSnapshot, options] = normalizeArgs(accessor, maybeGetSnapshot, accessorOptions);
   const defaultOptions = useContext(accessorOptionsContext);
   const requiredOptions = { ...defaultOptions, ...options };
   const { checkHasData } = requiredOptions;
+  const [subscribeData, getData] = useMemo(() => {
+    if (!accessor) return [() => noop, noop as () => undefined] as const;
+
+    const getState = () => {
+      return accessor.getState(serverStateKey);
+    };
+
+    let memoizedSnapshot = getSnapshot(getState());
+
+    return [
+      (listener: () => void) => {
+        return accessor.subscribeData(() => {
+          const snapshot = getSnapshot(getState());
+          if (stableHash(snapshot) !== stableHash(memoizedSnapshot)) {
+            memoizedSnapshot = snapshot;
+            listener();
+          }
+        });
+      },
+      () => memoizedSnapshot,
+    ] as const;
+  }, [accessor, serverStateKey]);
+  const data = useSyncExternalStore(subscribeData, getData, getData);
 
   if (!accessor) throw new Promise(noop);
 
-  const state = accessor.getState();
-  const snapshot = getSnapshot(state);
-  const hasData = checkHasData(snapshot);
+  const hasData = !isUndefined(data) ? checkHasData(data) : false;
 
-  if (!hasData) {
+  if (!hasData || !isNonUndefined(data)) {
     if (accessor.getStatus().isFetching) {
       throw new Promise(noop);
     } else {
@@ -80,7 +104,7 @@ export function useSuspenseAccessor<S, D, SS, E = unknown>(
   }
 
   return {
-    data: snapshot as NonNullable<SS>,
+    data,
     accessor,
   };
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -19,7 +19,7 @@ import type {
   Id,
 } from './adapters/index.js';
 import { createModel, createAutoModel } from './model/index.js';
-import { useAccessor, useHydrate, useModel } from './hooks/index.js';
+import { useAccessor, useHydrate, useModel, useSuspenseAccessor } from './hooks/index.js';
 import { createPaginationAdapter } from './adapters/index.js';
 import {
   AccessorOptionsProvider,
@@ -58,6 +58,7 @@ export {
   useAccessor,
   useHydrate,
   useModel,
+  useSuspenseAccessor,
 
   // adapter
   createPaginationAdapter,

--- a/src/lib/model/Accessor.ts
+++ b/src/lib/model/Accessor.ts
@@ -4,6 +4,10 @@ import type { MutableRefObject } from 'react';
 import { getKey, isUndefined } from '../utils/index.js';
 import type { BaseAction, BaseConstructorArgs, ModelSubscribe } from './types.js';
 
+export type RevalidateContext = {
+  serverStateKey?: object;
+};
+
 export type Status<E = unknown> = {
   isFetching: boolean;
   error: E | null;
@@ -49,7 +53,7 @@ export abstract class Accessor<S, Arg, D, E> {
   /**
    * Return the result of the revalidation.
    */
-  abstract revalidate: () => Promise<FetchPromiseResult<E, D>>;
+  abstract revalidate: (context?: RevalidateContext) => Promise<FetchPromiseResult<E, D>>;
 
   protected abstract action: BaseAction<Arg, D, E>;
 

--- a/src/lib/model/NormalAccessor.ts
+++ b/src/lib/model/NormalAccessor.ts
@@ -1,7 +1,7 @@
 import { getCurrentTime } from '../utils/index.js';
+import type { RevalidateContext } from './Accessor.js';
 import { Accessor } from './Accessor.js';
-import type { NormalAction, NormalConstructorArgs } from './types.js';
-import type { Draft } from 'immer';
+import type { NormalAction, NormalConstructorArgs, UpdateModelState } from './types.js';
 
 /**
  * [`data`, `error`]
@@ -15,7 +15,7 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
   E
 > {
   protected action: NormalAction<S, Arg, Data, E>;
-  private updateState: (cb: (draft: Draft<S>) => void) => void;
+  private updateState: UpdateModelState<S>;
 
   /**
    * @internal
@@ -41,7 +41,7 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
   /**
    * {@inheritDoc Accessor.revalidate}
    */
-  revalidate = () => {
+  revalidate = ({ serverStateKey }: RevalidateContext = {}) => {
     const startAt = getCurrentTime();
 
     if (!this.canFetch({ startAt })) {
@@ -62,7 +62,7 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
         if (data) {
           this.updateState(draft => {
             this.action.syncState(draft, { data, arg });
-          });
+          }, serverStateKey);
         }
         return this.onFetchingFinish({ error, data });
       } catch (error) {

--- a/src/lib/model/types.ts
+++ b/src/lib/model/types.ts
@@ -45,7 +45,7 @@ export type ModelSubscribe = (listener: () => void) => () => void;
 
 export interface BaseConstructorArgs<S, Arg> {
   arg: Arg;
-  updateState: (cb: (draft: Draft<S>) => void) => void;
+  updateState: UpdateModelState<S>;
   getState: (serverStateKey?: object) => S;
   modelSubscribe: ModelSubscribe;
   notifyModel: () => void;
@@ -63,3 +63,5 @@ export interface InfiniteConstructorArgs<S, Arg, Data, E> extends BaseConstructo
   action: InfiniteAction<S, Arg, Data, E>;
   initialPageNum: number;
 }
+
+export type UpdateModelState<S> = (cb: (draft: Draft<S>) => void, serverStateKey?: object) => void;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './getCurrentTime.js';
 export * from './getKey.js';
 export * from './isNonNullable.js';
+export * from './isNonUndefined.js';
 export * from './isNull.js';
 export * from './isNumber.js';
 export * from './isServer.js';
@@ -9,3 +10,4 @@ export * from './isUndefined.js';
 export * from './noop.js';
 export * from './objectKeys.js';
 export * from './stableHash.js';
+export * from './types.js';

--- a/src/lib/utils/isNonUndefined.ts
+++ b/src/lib/utils/isNonUndefined.ts
@@ -1,0 +1,6 @@
+import { isUndefined } from './isUndefined.js';
+import type { NonUndefined } from './types.js';
+
+export function isNonUndefined<T>(value: T): value is NonUndefined<T> {
+  return !isUndefined(value);
+}

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,0 +1,1 @@
+export type NonUndefined<T> = T extends undefined ? never : T;


### PR DESCRIPTION
## Proposed change

Since the logic is quite different when we want to use `Suspense`, I add a new API to achieve the goal.

This hook doesn't support streaming rendering out of box when using nextjs, we need to create another package to leverage it with nextjs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Testing
- [ ] Refactor
- [ ] Chore (tool changes, configuration changes, and changes to things that do not actually go into production at all)

## Implementation

## Related Issue

#182 