### PR TITLE
feat: support streaming rendering for nextjs

### DIFF
--- a/examples/next-streaming-rendering/app/page.tsx
+++ b/examples/next-streaming-rendering/app/page.tsx
@@ -43,9 +43,9 @@ function MyComponent({ wait }: { wait: number }) {
 
 export default function Home() {
   return (
-    <DatabaseProvider database={db}>
-      <StreamHydration>
-        <ServerStateKeyProvider>
+    <ServerStateKeyProvider value={{}}>
+      <DatabaseProvider database={db}>
+        <StreamHydration>
           <Suspense fallback={<div>waiting 100...</div>}>
             <MyComponent wait={100} />
           </Suspense>
@@ -86,8 +86,8 @@ export default function Home() {
               <MyComponent wait={1000} />
             </Suspense>
           </fieldset>
-        </ServerStateKeyProvider>
-      </StreamHydration>
-    </DatabaseProvider>
+        </StreamHydration>
+      </DatabaseProvider>
+    </ServerStateKeyProvider>
   );
 }

--- a/examples/next-streaming-rendering/app/page.tsx
+++ b/examples/next-streaming-rendering/app/page.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { ServerStateKeyProvider, createAutoModel, useSuspenseAccessor } from 'daxus';
+import {
+  ServerStateKeyProvider,
+  useSuspenseAccessor,
+  createDatabase,
+  DatabaseProvider,
+} from 'daxus';
+import { StreamHydration } from 'daxus-next';
 import { Suspense } from 'react';
 
 function getBaseUrl() {
@@ -14,9 +20,12 @@ function getBaseUrl() {
 }
 const baseUrl = getBaseUrl();
 
-const model = createAutoModel();
+const db = createDatabase();
+
+const model = db.createAutoModel({ name: 'test' });
 
 const getData = model.defineNormalAccessor({
+  name: 'getData',
   async fetchData(wait: number) {
     const path = `/api/wait?wait=${wait}`;
     const url = baseUrl + path;
@@ -34,47 +43,51 @@ function MyComponent({ wait }: { wait: number }) {
 
 export default function Home() {
   return (
-    <ServerStateKeyProvider>
-      <Suspense fallback={<div>waiting 100...</div>}>
-        <MyComponent wait={100} />
-      </Suspense>
-      <Suspense fallback={<div>waiting 200...</div>}>
-        <MyComponent wait={200} />
-      </Suspense>
-      <Suspense fallback={<div>waiting 300...</div>}>
-        <MyComponent wait={300} />
-      </Suspense>
-      <Suspense fallback={<div>waiting 400...</div>}>
-        <MyComponent wait={400} />
-      </Suspense>
-      <Suspense fallback={<div>waiting 500...</div>}>
-        <MyComponent wait={500} />
-      </Suspense>
-      <Suspense fallback={<div>waiting 600...</div>}>
-        <MyComponent wait={600} />
-      </Suspense>
-      <Suspense fallback={<div>waiting 700...</div>}>
-        <MyComponent wait={700} />
-      </Suspense>
+    <DatabaseProvider database={db}>
+      <StreamHydration>
+        <ServerStateKeyProvider>
+          <Suspense fallback={<div>waiting 100...</div>}>
+            <MyComponent wait={100} />
+          </Suspense>
+          <Suspense fallback={<div>waiting 200...</div>}>
+            <MyComponent wait={200} />
+          </Suspense>
+          <Suspense fallback={<div>waiting 300...</div>}>
+            <MyComponent wait={300} />
+          </Suspense>
+          <Suspense fallback={<div>waiting 400...</div>}>
+            <MyComponent wait={400} />
+          </Suspense>
+          <Suspense fallback={<div>waiting 500...</div>}>
+            <MyComponent wait={500} />
+          </Suspense>
+          <Suspense fallback={<div>waiting 600...</div>}>
+            <MyComponent wait={600} />
+          </Suspense>
+          <Suspense fallback={<div>waiting 700...</div>}>
+            <MyComponent wait={700} />
+          </Suspense>
 
-      <fieldset>
-        <legend>
-          combined <code>Suspense</code> container
-        </legend>
-        <Suspense
-          fallback={
-            <>
-              <div>waiting 800</div>
-              <div>waiting 900</div>
-              <div>waiting 1000</div>
-            </>
-          }
-        >
-          <MyComponent wait={800} />
-          <MyComponent wait={900} />
-          <MyComponent wait={1000} />
-        </Suspense>
-      </fieldset>
-    </ServerStateKeyProvider>
+          <fieldset>
+            <legend>
+              combined <code>Suspense</code> container
+            </legend>
+            <Suspense
+              fallback={
+                <>
+                  <div>waiting 800</div>
+                  <div>waiting 900</div>
+                  <div>waiting 1000</div>
+                </>
+              }
+            >
+              <MyComponent wait={800} />
+              <MyComponent wait={900} />
+              <MyComponent wait={1000} />
+            </Suspense>
+          </fieldset>
+        </ServerStateKeyProvider>
+      </StreamHydration>
+    </DatabaseProvider>
   );
 }

--- a/examples/next-streaming-rendering/package.json
+++ b/examples/next-streaming-rendering/package.json
@@ -16,6 +16,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.6",
-    "daxus": "workspace:*"
+    "daxus": "workspace:*",
+    "daxus-next": "workspace:*"
   }
 }

--- a/packages/daxus-next/package.json
+++ b/packages/daxus-next/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "daxus-next",
+  "version": "0.6.0-beta.3",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "react",
+    "data fetching",
+    "auto revalidate",
+    "pagination"
+  ],
+  "author": {
+    "name": "Yu Xuan",
+    "email": "97ssps30212@gmail.com",
+    "url": "https://github.com/jason89521"
+  },
+  "types": "./dist/index.d.ts",
+  "module": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jason89521/daxus"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "pnpm run build-lib"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.1.6",
+    "daxus": "workspace:*",
+    "next": "13.4.12"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "daxus": "workspace:*",
+    "next": "13.4.12"
+  }
+}

--- a/packages/daxus-next/src/StreamHydration.tsx
+++ b/packages/daxus-next/src/StreamHydration.tsx
@@ -81,7 +81,6 @@ export function StreamHydration({ children }: Props) {
     const onPush = (...ctxs: NotifyDatabaseContext[]) => {
       ctxs.forEach(ctx => {
         const model = database.getModel(ctx.modelName);
-        if (isUndefined(ctx.creatorName) || isUndefined(ctx.data)) return;
         const creator = model?.getCreator(ctx.creatorName);
         if (!creator) return;
         creator.mutate(draft => {

--- a/packages/daxus-next/src/StreamHydration.tsx
+++ b/packages/daxus-next/src/StreamHydration.tsx
@@ -10,6 +10,20 @@ interface Props {
   children: ReactNode;
 }
 
+const ESCAPE_LOOKUP: { [match: string]: string } = {
+  '&': '\\u0026',
+  '>': '\\u003e',
+  '<': '\\u003c',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+};
+
+const ESCAPE_REGEX = /[&><\u2028\u2029]/g;
+
+function htmlEscapeJsonString(str: string): string {
+  return str.replace(ESCAPE_REGEX, match => ESCAPE_LOOKUP[match]!);
+}
+
 function isServer() {
   return typeof window === 'undefined';
 }
@@ -51,7 +65,7 @@ export function StreamHydration({ children }: Props) {
         dangerouslySetInnerHTML={{
           __html: `
         window['__daxus'] = window['__daxus'] ?? [];
-        window['__daxus'].push(${serializedCtxs})
+        window['__daxus'].push(${htmlEscapeJsonString(serializedCtxs)})
       `,
         }}
       />

--- a/packages/daxus-next/src/StreamHydration.tsx
+++ b/packages/daxus-next/src/StreamHydration.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useDatabaseContext } from 'daxus';
+import { useDatabaseContext, useServerStateKeyContext } from 'daxus';
 import type { NotifyDatabaseContext } from 'daxus/dist/model/types.js';
 import { InfiniteAccessor } from 'daxus/dist/model/index.js';
 import { useState, type ReactNode, useEffect, useRef } from 'react';
@@ -20,12 +20,14 @@ function isUndefined(value: unknown): value is undefined {
 
 export function StreamHydration({ children }: Props) {
   const database = useDatabaseContext();
+  const serverStateKey = useServerStateKeyContext();
   const [trackedCtx] = useState(() => new Set<NotifyDatabaseContext>());
   if (!database) throw new Error('Should be wrapped with a database provider!');
+  if (!serverStateKey) throw new Error('Should be wrapped with a serverStateKey provider');
 
   // server stuff
   if (isServer()) {
-    database.subscribe(ctx => {
+    database.subscribe(serverStateKey, ctx => {
       trackedCtx.add(ctx);
     });
   }

--- a/packages/daxus-next/src/StreamHydration.tsx
+++ b/packages/daxus-next/src/StreamHydration.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useDatabaseContext } from 'daxus';
+import type { NotifyDatabaseContext } from 'daxus/dist/model/types.js';
+import { InfiniteAccessor } from 'daxus/dist/model/index.js';
+import { useState, type ReactNode, useEffect, useRef } from 'react';
+import { useServerInsertedHTML } from 'next/navigation.js';
+
+interface Props {
+  children: ReactNode;
+}
+
+function isServer() {
+  return typeof window === 'undefined';
+}
+
+function isUndefined(value: unknown): value is undefined {
+  return typeof value === 'undefined';
+}
+
+export function StreamHydration({ children }: Props) {
+  const database = useDatabaseContext();
+  const [trackedCtx] = useState(() => new Set<NotifyDatabaseContext>());
+  if (!database) throw new Error('Should be wrapped with a database provider!');
+
+  // server stuff
+  if (isServer()) {
+    database.subscribe(ctx => {
+      trackedCtx.add(ctx);
+    });
+  }
+
+  const countRef = useRef(0);
+  useServerInsertedHTML(() => {
+    const ctxs: NotifyDatabaseContext[] = [];
+    trackedCtx.forEach(ctx => {
+      ctxs.push(ctx);
+    });
+    trackedCtx.clear();
+
+    if (!ctxs.length) return null;
+
+    const serializedCtxs = ctxs.map(ctx => JSON.stringify(ctx)).join(',');
+
+    countRef.current++;
+    return (
+      <script
+        key={countRef.current}
+        dangerouslySetInnerHTML={{
+          __html: `
+        window['__daxus'] = window['__daxus'] ?? [];
+        window['__daxus'].push(${serializedCtxs})
+      `,
+        }}
+      />
+    );
+  });
+  // server stuff
+
+  // client stuff
+  useEffect(() => {
+    const win = window as any;
+    const ctxs: NotifyDatabaseContext[] = win['__daxus'] ?? [];
+
+    const onPush = (...ctxs: NotifyDatabaseContext[]) => {
+      ctxs.forEach(ctx => {
+        const model = database.getModel(ctx.modelName);
+        if (isUndefined(ctx.creatorName) || isUndefined(ctx.data)) return;
+        const creator = model?.getCreator(ctx.creatorName);
+        if (!creator) return;
+        creator.mutate(draft => {
+          const accessor = creator(ctx.arg);
+          if (accessor instanceof InfiniteAccessor) {
+            if (isUndefined(ctx.pageIndex) || isUndefined(ctx.pageSize)) return;
+            creator.syncState(draft, ctx as any);
+            return;
+          }
+
+          creator.syncState(draft, ctx as any);
+        });
+      });
+    };
+
+    onPush(...ctxs);
+
+    win['__daxus'] = {
+      push: onPush,
+    };
+
+    return () => {
+      win['__daxus'] = [];
+    };
+  }, [database]);
+  // client stuff
+
+  return <>{children}</>;
+}

--- a/packages/daxus-next/src/index.ts
+++ b/packages/daxus-next/src/index.ts
@@ -1,0 +1,1 @@
+export * from './StreamHydration.js';

--- a/packages/daxus-next/tsconfig.json
+++ b/packages/daxus-next/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "noUncheckedIndexedAccess": true,
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "stripInternal": true,
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/daxus/src/__tests__/useAccessor-autoModel.test.tsx
+++ b/packages/daxus/src/__tests__/useAccessor-autoModel.test.tsx
@@ -1,11 +1,13 @@
 import { act, fireEvent, renderHook, waitFor } from '@testing-library/react';
-import { createAutoModel, useAccessor } from '../lib/index.js';
+import { createDatabase, useAccessor } from '../lib/index.js';
 import { renderWithOptionsProvider } from './utils.js';
 
-let model = createAutoModel();
+let db = createDatabase();
+let model = db.createAutoModel({ name: 'test' });
 
 beforeEach(() => {
-  model = createAutoModel();
+  db = createDatabase();
+  model = db.createAutoModel({ name: 'test' });
 });
 
 describe('autoModel', () => {

--- a/packages/daxus/src/__tests__/useAccessor-autoModel.test.tsx
+++ b/packages/daxus/src/__tests__/useAccessor-autoModel.test.tsx
@@ -11,6 +11,7 @@ beforeEach(() => {
 describe('autoModel', () => {
   test('should mutate the data correctly', () => {
     const getData = model.defineNormalAccessor<string>({
+      name: 'getData',
       fetchData: async () => {
         return 'data';
       },
@@ -31,6 +32,7 @@ describe('autoModel', () => {
 describe('useAccessor - normal with auto state', () => {
   test('should return correct data', async () => {
     const getData = model.defineNormalAccessor<string>({
+      name: 'getData',
       fetchData: async () => {
         return 'data';
       },
@@ -44,6 +46,7 @@ describe('useAccessor - normal with auto state', () => {
 
   test('should return selected data', async () => {
     const getData = model.defineNormalAccessor<string>({
+      name: 'getData',
       fetchData: async () => {
         return 'data';
       },
@@ -62,11 +65,13 @@ describe('useAccessor - normal with auto state', () => {
   test('should notify accessor itself only', async () => {
     let notifiedCount = 0;
     const getStaticData = model.defineNormalAccessor<string>({
+      name: 'getStaticData',
       fetchData: async () => {
         return 'static';
       },
     });
     const getDynamicData = model.defineNormalAccessor<string>({
+      name: 'getDynamicData',
       fetchData: async () => {
         return `${notifiedCount}`;
       },
@@ -116,6 +121,7 @@ describe('useAccessor - normal with auto state', () => {
 describe('useAccessor - infinite with auto state', () => {
   test('should return correct data', async () => {
     const getData = model.defineInfiniteAccessor<string[]>({
+      name: 'getData',
       fetchData: async () => {
         return ['data'];
       },
@@ -140,6 +146,7 @@ describe('useAccessor - infinite with auto state', () => {
 
   test('should return selected data', async () => {
     const getData = model.defineInfiniteAccessor<string[]>({
+      name: 'getData',
       fetchData: async () => {
         return ['data'];
       },

--- a/packages/daxus/src/__tests__/useSuspenseAccessor.test.tsx
+++ b/packages/daxus/src/__tests__/useSuspenseAccessor.test.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState } from 'react';
-import { createAutoModel, useSuspenseAccessor } from '../lib/index.js';
+import { createDatabase, useSuspenseAccessor } from '../lib/index.js';
 import { createControl, createPostModel, renderWithOptionsProvider } from './utils.js';
 import { fireEvent } from '@testing-library/react';
 import { isUndefined } from '../lib/utils/isUndefined.js';
@@ -88,14 +88,17 @@ describe('useSuspenseAccessor-normal', () => {
 });
 
 describe('useSuspenseAccessor-auto state', () => {
-  let model = createAutoModel();
+  let db = createDatabase();
+  let model = db.createAutoModel({ name: 'test' });
 
   beforeEach(() => {
-    model = createAutoModel();
+    db = createDatabase();
+    model = db.createAutoModel({ name: 'test' });
   });
 
   test('should show the data when fetching finish', async () => {
     const getData = model.defineNormalAccessor({
+      name: 'getData',
       async fetchData() {
         return 'data';
       },
@@ -122,6 +125,7 @@ describe('useSuspenseAccessor-auto state', () => {
   test('should update the data when the corresponding cache is updated', async () => {
     let counter = 0;
     const getData = model.defineNormalAccessor({
+      name: 'getData',
       async fetchData() {
         counter += 1;
         return counter;

--- a/packages/daxus/src/__tests__/utils.tsx
+++ b/packages/daxus/src/__tests__/utils.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { AccessorOptionsProvider, createModel, createPaginationAdapter } from '../lib/index.js';
+import { AccessorOptionsProvider, createDatabase, createPaginationAdapter } from '../lib/index.js';
 import type { PostModelControl } from './types.js';
 import type { Post, PostLayout } from '../types.js';
 import { render } from '@testing-library/react';
@@ -14,8 +14,9 @@ export function createPost(id: number, layout: PostLayout = 'classic'): Post {
 }
 
 export function createPostModel(control: PostModelControl) {
+  const db = createDatabase();
   const postAdapter = createPaginationAdapter<Post>({});
-  const postModel = createModel(postAdapter.initialState);
+  const postModel = db.createModel({ name: 'post', initialState: postAdapter.initialState });
   const getPostById = postModel.defineNormalAccessor({
     name: 'getPostById',
     fetchData: async (id: number) => {

--- a/packages/daxus/src/__tests__/utils.tsx
+++ b/packages/daxus/src/__tests__/utils.tsx
@@ -17,6 +17,7 @@ export function createPostModel(control: PostModelControl) {
   const postAdapter = createPaginationAdapter<Post>({});
   const postModel = createModel(postAdapter.initialState);
   const getPostById = postModel.defineNormalAccessor({
+    name: 'getPostById',
     fetchData: async (id: number) => {
       control.fetchDataMock?.();
 
@@ -46,6 +47,7 @@ export function createPostModel(control: PostModelControl) {
   });
 
   const getPostList = postModel.defineInfiniteAccessor<Post[]>({
+    name: 'getPostList',
     async fetchData(_, { pageIndex }) {
       control.fetchDataMock?.();
 

--- a/packages/daxus/src/lib/contexts/DatabaseContext.tsx
+++ b/packages/daxus/src/lib/contexts/DatabaseContext.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+import type { Database } from '../model/createDatabase.js';
+
+export const DatabaseContext = createContext<Database | undefined>(undefined);
+
+export function useDatabaseContext() {
+  return useContext(DatabaseContext);
+}
+
+export function DatabaseProvider({
+  database,
+  children,
+}: {
+  database: Database;
+  children: ReactNode;
+}) {
+  return <DatabaseContext.Provider value={database}>{children}</DatabaseContext.Provider>;
+}

--- a/packages/daxus/src/lib/contexts/ServerStateKeyContext.tsx
+++ b/packages/daxus/src/lib/contexts/ServerStateKeyContext.tsx
@@ -1,18 +1,17 @@
 import type { ReactNode } from 'react';
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext } from 'react';
 
-const serverStateKeyContext = createContext<object>({});
+const serverStateKeyContext = createContext<object | undefined>(undefined);
 
 export interface ServerStateKeyProviderProps {
   children: ReactNode;
+  value: object;
 }
 
 export function useServerStateKeyContext() {
   return useContext(serverStateKeyContext);
 }
 
-export function ServerStateKeyProvider({ children }: ServerStateKeyProviderProps) {
-  const value = useMemo(() => ({}), []);
-
+export function ServerStateKeyProvider({ children, value }: ServerStateKeyProviderProps) {
   return <serverStateKeyContext.Provider value={value}>{children}</serverStateKeyContext.Provider>;
 }

--- a/packages/daxus/src/lib/contexts/index.ts
+++ b/packages/daxus/src/lib/contexts/index.ts
@@ -1,2 +1,3 @@
 export * from './AccessorOptionsContext.js';
 export * from './ServerStateKeyContext.js';
+export * from './DatabaseContext.js';

--- a/packages/daxus/src/lib/index.ts
+++ b/packages/daxus/src/lib/index.ts
@@ -18,13 +18,15 @@ import type {
   PaginationState,
   Id,
 } from './adapters/index.js';
-import { createModel, createAutoModel } from './model/index.js';
+import { createModel, createAutoModel, createDatabase } from './model/index.js';
 import { useAccessor, useHydrate, useModel, useSuspenseAccessor } from './hooks/index.js';
 import { createPaginationAdapter } from './adapters/index.js';
 import {
   AccessorOptionsProvider,
   ServerStateKeyProvider,
   useServerStateKeyContext,
+  DatabaseProvider,
+  useDatabaseContext,
 } from './contexts/index.js';
 
 export type {
@@ -53,6 +55,7 @@ export type {
 export {
   createModel,
   createAutoModel,
+  createDatabase,
 
   // hook
   useAccessor,
@@ -67,4 +70,6 @@ export {
   AccessorOptionsProvider,
   ServerStateKeyProvider,
   useServerStateKeyContext,
+  DatabaseProvider,
+  useDatabaseContext,
 };

--- a/packages/daxus/src/lib/model/Accessor.ts
+++ b/packages/daxus/src/lib/model/Accessor.ts
@@ -33,6 +33,7 @@ export abstract class Accessor<S, Arg, D, E> {
   protected statusListeners: ((prev: Status, current: Status) => void)[] = [];
   protected fetchPromise!: Promise<FetchPromiseResult<E, D>>;
   protected arg: Arg;
+  protected creatorName: string;
   private notifyModel: () => void;
   private retryTimeoutMeta: RetryTimeoutMeta | null = null;
   private startAt = 0;
@@ -45,7 +46,6 @@ export abstract class Accessor<S, Arg, D, E> {
   private isStale = false;
   private onMount: () => void;
   private onUnmount: () => void;
-  private prefix: number;
   private autoListeners: (() => void)[] = [];
   private removeAllListeners: (() => void) | null = null;
   private isAuto: boolean;
@@ -71,28 +71,21 @@ export abstract class Accessor<S, Arg, D, E> {
     onMount,
     onUnmount,
     notifyModel,
-    prefix,
     arg,
     isAuto,
+    creatorName,
   }: Pick<
     BaseConstructorArgs<S, Arg>,
-    | 'getState'
-    | 'modelSubscribe'
-    | 'onMount'
-    | 'onUnmount'
-    | 'prefix'
-    | 'arg'
-    | 'notifyModel'
-    | 'isAuto'
-  >) {
+    'getState' | 'modelSubscribe' | 'onMount' | 'onUnmount' | 'arg' | 'notifyModel' | 'isAuto'
+  > & { creatorName: string }) {
     this.getState = getState;
     this.modelSubscribe = modelSubscribe;
     this.onMount = onMount;
     this.onUnmount = onUnmount;
     this.notifyModel = notifyModel;
-    this.prefix = prefix;
     this.arg = arg;
     this.isAuto = isAuto;
+    this.creatorName = creatorName;
   }
 
   getIsAuto = () => {
@@ -100,7 +93,7 @@ export abstract class Accessor<S, Arg, D, E> {
   };
 
   getKey = () => {
-    return getKey(this.prefix, this.arg);
+    return getKey(this.creatorName, this.arg);
   };
 
   /**

--- a/packages/daxus/src/lib/model/InfiniteAccessor.ts
+++ b/packages/daxus/src/lib/model/InfiniteAccessor.ts
@@ -35,11 +35,19 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Acc
     notifyModel,
     onMount,
     onUnmount,
-    prefix,
     initialPageNum,
     isAuto,
   }: InfiniteConstructorArgs<S, Arg, Data, E>) {
-    super({ getState, modelSubscribe, onMount, onUnmount, arg, prefix, notifyModel, isAuto });
+    super({
+      getState,
+      modelSubscribe,
+      onMount,
+      onUnmount,
+      arg,
+      creatorName: action.name,
+      notifyModel,
+      isAuto,
+    });
     this.action = action;
     this.updateState = updateState;
     this.initialPageNum = initialPageNum;
@@ -172,14 +180,18 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Acc
         if (!error) {
           for (let i = 0; i < data.length; i++) {
             if (i < pageIndex) continue;
-            this.updateState(draft => {
-              this.action.syncState(draft, {
-                arg: this.arg,
-                pageIndex: i,
-                pageSize: data.length,
-                data: data[i]!,
-              });
-            }, serverStateKey);
+            const payload = {
+              arg: this.arg,
+              pageIndex: i,
+              pageSize: data.length,
+              data: data[i]!,
+            };
+            this.updateState(
+              draft => {
+                this.action.syncState(draft, payload);
+              },
+              { serverStateKey, ...payload, creatorName: this.creatorName }
+            );
           }
           this.data = data;
         }

--- a/packages/daxus/src/lib/model/Model.ts
+++ b/packages/daxus/src/lib/model/Model.ts
@@ -18,7 +18,6 @@ const CLEAR_ACCESSOR_CACHE_TIME = 60 * 1000;
 interface BaseAccessorCreator<S> {
   mutate: (fn: (draft: Draft<S>) => void) => void;
   invalidate(): void;
-  isAuto: boolean;
 }
 
 export type AutoState = Record<string, unknown>;
@@ -219,7 +218,6 @@ export function createModel<S extends object>(
           }
         });
       },
-      isAuto: action.isAuto ?? false,
       mutate,
       syncState: action.syncState,
     });
@@ -293,7 +291,6 @@ export function createModel<S extends object>(
           }
         });
       },
-      isAuto: action.isAuto ?? false,
       mutate,
       syncState: action.syncState,
     });

--- a/packages/daxus/src/lib/model/Model.ts
+++ b/packages/daxus/src/lib/model/Model.ts
@@ -87,7 +87,7 @@ export interface AutoModel
 
 export function createModel<S extends object>(
   initialState: S,
-  onStateChange: (ctx: UpdateModelStateContext) => void
+  onServerStateChange: (ctx: UpdateModelStateContext) => void
 ): Model<S> {
   type Accessor<Arg = any, Data = any> =
     | NormalAccessor<S, Arg, Data, any>
@@ -119,14 +119,13 @@ export function createModel<S extends object>(
       const draft = createDraft(serverState);
       fn(draft);
       serverStateRecord.set(serverStateKey, finishDraft(draft) as S);
-      onStateChange(ctx);
+      onServerStateChange({ ...ctx, serverStateKey });
       return;
     }
 
     const draft = createDraft(clientState);
     fn(draft);
     clientState = finishDraft(draft) as S;
-    onStateChange(ctx);
   };
 
   function getState(serverStateKey?: object) {
@@ -322,8 +321,10 @@ export function createModel<S extends object>(
   };
 }
 
-export function createAutoModel(onStateChange: (ctx: UpdateModelStateContext) => void): AutoModel {
-  const model = createModel<AutoState>({}, onStateChange);
+export function createAutoModel(
+  onServerStateChange: (ctx: UpdateModelStateContext) => void
+): AutoModel {
+  const model = createModel<AutoState>({}, onServerStateChange);
 
   function defineNormalAccessor<Arg, Data, E = unknown>(action: AutoNormalAction<Arg, Data, E>) {
     const { name } = action;

--- a/packages/daxus/src/lib/model/Model.ts
+++ b/packages/daxus/src/lib/model/Model.ts
@@ -5,16 +5,20 @@ import type {
   NormalAction,
   InfiniteConstructorArgs,
   NormalConstructorArgs,
+  UpdateModelState,
+  UpdateModelStateContext,
 } from './types.js';
 import { NormalAccessor } from './NormalAccessor.js';
 import { InfiniteAccessor } from './InfiniteAccessor.js';
-import { getKey, isServer } from '../utils/index.js';
+import { getKey, isServer, objectKeys } from '../utils/index.js';
 import type { Accessor } from './Accessor.js';
 
 const CLEAR_ACCESSOR_CACHE_TIME = 60 * 1000;
 
-interface BaseAccessorCreator {
+interface BaseAccessorCreator<S> {
+  mutate: (fn: (draft: Draft<S>) => void) => void;
   invalidate(): void;
+  isAuto: boolean;
 }
 
 export type AutoState = Record<string, unknown>;
@@ -29,14 +33,21 @@ export type AutoInfiniteAction<Arg, Data, E> = Omit<
   'syncState'
 >;
 
-export interface NormalAccessorCreator<S, Arg, Data, E> extends BaseAccessorCreator {
+export interface NormalAccessorCreator<S, Arg = any, Data = any, E = any>
+  extends BaseAccessorCreator<S> {
   (arg: Arg): NormalAccessor<S, Arg, Data, E>;
+  syncState: NormalAction<S, Arg, Data, E>['syncState'];
 }
-export interface InfiniteAccessorCreator<S, Arg, Data, E> extends BaseAccessorCreator {
+export interface InfiniteAccessorCreator<S, Arg = any, Data = any, E = any>
+  extends BaseAccessorCreator<S> {
   (arg: Arg): InfiniteAccessor<S, Arg, Data, E>;
+  syncState: InfiniteAction<S, Arg, Data, E>['syncState'];
 }
 
 export interface Model<S extends object> {
+  getCreator(
+    creatorName: string
+  ): InfiniteAccessorCreator<S> | NormalAccessorCreator<S> | undefined;
   mutate(fn: (draft: Draft<S>) => void, serverStateKey?: object): void;
   defineInfiniteAccessor<Data, Arg = void, E = any>(
     action: InfiniteAction<S, Arg, Data, E>
@@ -55,7 +66,8 @@ export interface Model<S extends object> {
   subscribe(listener: () => void): () => void;
 }
 
-export interface AutoModel extends Pick<Model<AutoState>, 'invalidate' | 'subscribe'> {
+export interface AutoModel
+  extends Pick<Model<AutoState>, 'invalidate' | 'subscribe' | 'getCreator'> {
   mutate<Arg, Data, E = unknown>(
     accessor: Accessor<AutoState, Arg, Data, E>,
     fn: (prevData: Data | undefined) => Data,
@@ -73,34 +85,49 @@ export interface AutoModel extends Pick<Model<AutoState>, 'invalidate' | 'subscr
   ): Data | undefined;
 }
 
-export function createModel<S extends object>(initialState: S): Model<S> {
+export function createModel<S extends object>(
+  initialState: S,
+  onStateChange: (ctx: UpdateModelStateContext) => void
+): Model<S> {
   type Accessor<Arg = any, Data = any> =
     | NormalAccessor<S, Arg, Data, any>
     | InfiniteAccessor<S, Arg, Data, any>;
 
-  let prefixCounter = 0;
   const serverStateRecord = new WeakMap<object, S>();
   let clientState = { ...initialState };
   const listeners: (() => void)[] = [];
   const accessorRecord = {} as Record<string, Accessor | undefined>;
+  const creatorRecord = {} as Record<
+    string,
+    NormalAccessorCreator<S, any, any, any> | InfiniteAccessorCreator<S, any, any, any> | undefined
+  >;
+
+  function assertDuplicateName(name: string) {
+    if (objectKeys(creatorRecord).includes(name)) {
+      throw new Error(`The creator name: ${name} has already existed!`);
+    }
+  }
+
   /**
    * instead of recording the whole data, we only record the pages number to save the memory usage
    */
   const infiniteAccessorPageNumRecord = {} as Record<string, number | undefined>;
 
-  function updateState(fn: (draft: Draft<S>) => void, serverStateKey?: object) {
+  const updateState: UpdateModelState<S> = (fn, { serverStateKey, ...ctx }) => {
     if (isServer() && serverStateKey) {
       const serverState = serverStateRecord.get(serverStateKey) ?? { ...initialState };
       const draft = createDraft(serverState);
       fn(draft);
       serverStateRecord.set(serverStateKey, finishDraft(draft) as S);
+      onStateChange(ctx);
       return;
     }
 
     const draft = createDraft(clientState);
     fn(draft);
     clientState = finishDraft(draft) as S;
-  }
+    onStateChange(ctx);
+  };
 
   function getState(serverStateKey?: object) {
     if (isServer() && serverStateKey) {
@@ -125,17 +152,18 @@ export function createModel<S extends object>(initialState: S): Model<S> {
   }
 
   function mutate(fn: (draft: Draft<S>) => void, serverStateKey?: object) {
-    updateState(fn, serverStateKey);
+    updateState(fn, { serverStateKey });
     notifyListeners();
   }
 
   function defineNormalAccessor<Arg, Data, E = unknown>(
     action: NormalAction<S, Arg, Data, E>
   ): NormalAccessorCreator<S, Arg, Data, E> {
-    const prefix = action.prefix ?? prefixCounter++;
+    const { name } = action;
+    assertDuplicateName(name);
     let timeoutId: number | undefined;
     const main = (arg: Arg) => {
-      const key = getKey(prefix, arg);
+      const key = getKey(name, arg);
 
       const clearAccessorCache = () => {
         const accessor = accessorRecord[key];
@@ -162,7 +190,6 @@ export function createModel<S extends object>(initialState: S): Model<S> {
         notifyModel: notifyListeners,
         onMount,
         onUnmount,
-        prefix,
         isAuto: action.isAuto ?? false,
       };
 
@@ -185,24 +212,32 @@ export function createModel<S extends object>(initialState: S): Model<S> {
       return newAccessor;
     };
 
-    return Object.assign(main, {
+    const creator = Object.assign(main, {
       invalidate: () => {
         Object.entries(accessorRecord).forEach(([key, accessor]) => {
-          if (key.startsWith(`${prefix}/`)) {
+          if (key.startsWith(`${name}/`)) {
             accessor?.invalidate();
           }
         });
       },
+      isAuto: action.isAuto ?? false,
+      mutate,
+      syncState: action.syncState,
     });
+
+    creatorRecord[name] = creator;
+
+    return creator;
   }
 
   function defineInfiniteAccessor<Arg, Data, E = unknown>(
     action: InfiniteAction<S, Arg, Data, E>
   ): InfiniteAccessorCreator<S, Arg, Data, E> {
-    const prefix = action.prefix ?? prefixCounter++;
+    const { name } = action;
+    assertDuplicateName(name);
     let timeoutId: number | undefined;
     const main = (arg: Arg) => {
-      const key = getKey(prefix, arg);
+      const key = getKey(name, arg);
 
       const clearAccessorCache = () => {
         const accessor = accessorRecord[key] as InfiniteAccessor<S>;
@@ -230,7 +265,6 @@ export function createModel<S extends object>(initialState: S): Model<S> {
         updateState,
         onMount,
         onUnmount,
-        prefix,
         initialPageNum: infiniteAccessorPageNumRecord[key] ?? 1,
         isAuto: action.isAuto ?? false,
       };
@@ -252,15 +286,21 @@ export function createModel<S extends object>(initialState: S): Model<S> {
       return newAccessor;
     };
 
-    return Object.assign(main, {
+    const creator = Object.assign(main, {
       invalidate: () => {
         Object.entries(accessorRecord).forEach(([key, accessor]) => {
-          if (key.startsWith(`${prefix}/`)) {
+          if (key.startsWith(`${name}/`)) {
             accessor?.invalidate();
           }
         });
       },
+      isAuto: action.isAuto ?? false,
+      mutate,
+      syncState: action.syncState,
     });
+    creatorRecord[name] = creator;
+
+    return creator;
   }
 
   function invalidate() {
@@ -269,21 +309,29 @@ export function createModel<S extends object>(initialState: S): Model<S> {
     });
   }
 
-  return { mutate, defineInfiniteAccessor, defineNormalAccessor, getState, invalidate, subscribe };
+  return {
+    mutate,
+    defineInfiniteAccessor,
+    defineNormalAccessor,
+    getState,
+    invalidate,
+    subscribe,
+    getCreator(creatorName) {
+      return creatorRecord[creatorName];
+    },
+  };
 }
 
-export function createAutoModel(): AutoModel {
-  const model = createModel<AutoState>({});
-  let prefixCounter = 0;
+export function createAutoModel(onStateChange: (ctx: UpdateModelStateContext) => void): AutoModel {
+  const model = createModel<AutoState>({}, onStateChange);
 
   function defineNormalAccessor<Arg, Data, E = unknown>(action: AutoNormalAction<Arg, Data, E>) {
-    const prefix = prefixCounter++;
+    const { name } = action;
     return model.defineNormalAccessor({
       ...action,
-      prefix,
       isAuto: true,
       syncState(draft, { data, arg }) {
-        const key = getKey(prefix, arg);
+        const key = getKey(name, arg);
         draft[key] = data;
       },
     });
@@ -292,13 +340,13 @@ export function createAutoModel(): AutoModel {
   function defineInfiniteAccessor<Arg, Data, E = unknown>(
     action: AutoInfiniteAction<Arg, Data, E>
   ) {
-    const prefix = prefixCounter++;
+    const { name } = action;
+
     return model.defineInfiniteAccessor({
       ...action,
-      prefix,
       isAuto: true,
       syncState(draft, { pageIndex, data, arg }) {
-        const key = getKey(prefix, arg);
+        const key = getKey(name, arg);
         if (pageIndex === 0) {
           draft[key] = [data];
           return;

--- a/packages/daxus/src/lib/model/NormalAccessor.ts
+++ b/packages/daxus/src/lib/model/NormalAccessor.ts
@@ -29,10 +29,18 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
     notifyModel,
     onMount,
     onUnmount,
-    prefix,
     isAuto,
   }: NormalConstructorArgs<S, Arg, Data, E>) {
-    super({ getState, modelSubscribe, onMount, onUnmount, arg, prefix, notifyModel, isAuto });
+    super({
+      getState,
+      modelSubscribe,
+      onMount,
+      onUnmount,
+      arg,
+      creatorName: action.name,
+      notifyModel,
+      isAuto,
+    });
     this.action = action;
     this.arg = arg;
     this.updateState = updateState;
@@ -60,9 +68,12 @@ export class NormalAccessor<S, Arg = any, Data = any, E = unknown> extends Acces
         this.updateStartAt(startAt);
 
         if (data) {
-          this.updateState(draft => {
-            this.action.syncState(draft, { data, arg });
-          }, serverStateKey);
+          this.updateState(
+            draft => {
+              this.action.syncState(draft, { data, arg });
+            },
+            { serverStateKey, data, arg, creatorName: this.creatorName }
+          );
         }
         return this.onFetchingFinish({ error, data });
       } catch (error) {

--- a/packages/daxus/src/lib/model/createDatabase.ts
+++ b/packages/daxus/src/lib/model/createDatabase.ts
@@ -1,0 +1,67 @@
+import type { AutoModel, Model } from './Model.js';
+import { createModel as origCreateModel, createAutoModel as origCreateAutoModel } from './Model.js';
+import { objectKeys } from '../utils/index.js';
+import type { NotifyDatabaseContext } from './types.js';
+
+export interface Database {
+  createModel<S extends object>(ctx: { name: string; initialState: S }): Model<S>;
+  createAutoModel(ctx: { name: string }): AutoModel;
+  subscribe(cb: (ctx: NotifyDatabaseContext) => void): void;
+  getModel(modelName: string): Model<any> | AutoModel | undefined;
+}
+
+export function createDatabase(): Database {
+  const modelRecord: Record<string, Model<any> | AutoModel | undefined> = {};
+  const listeners: ((ctx: NotifyDatabaseContext) => void)[] = [];
+
+  function assertDuplicateName(name: string) {
+    if (objectKeys(modelRecord).includes(name)) {
+      throw new Error(`The model name: ${name} has already existed!`);
+    }
+  }
+
+  function subscribe(cb: (ctx: NotifyDatabaseContext) => void) {
+    listeners.push(cb);
+    return () => {
+      const index = listeners.indexOf(cb);
+      listeners.splice(index, 1);
+    };
+  }
+
+  function onStateChange(ctx: NotifyDatabaseContext) {
+    listeners.forEach(l => l(ctx));
+  }
+
+  function createModel<S extends object>({
+    name,
+    initialState,
+  }: {
+    name: string;
+    initialState: S;
+  }) {
+    assertDuplicateName(name);
+    const model = origCreateModel(initialState, ctx => {
+      onStateChange({ ...ctx, modelName: name });
+    });
+    modelRecord[name] = model;
+    return model;
+  }
+
+  function createAutoModel({ name }: { name: string }) {
+    assertDuplicateName(name);
+    const model = origCreateAutoModel(ctx => {
+      onStateChange({ ...ctx, modelName: name });
+    });
+    modelRecord[name] = model;
+    return model;
+  }
+
+  return {
+    createModel,
+    createAutoModel,
+    subscribe,
+    getModel(modelName) {
+      return modelRecord[modelName];
+    },
+  };
+}

--- a/packages/daxus/src/lib/model/createDatabase.ts
+++ b/packages/daxus/src/lib/model/createDatabase.ts
@@ -1,17 +1,26 @@
 import type { AutoModel, Model } from './Model.js';
 import { createModel as origCreateModel, createAutoModel as origCreateAutoModel } from './Model.js';
-import { objectKeys } from '../utils/index.js';
+import { isUndefined, objectKeys } from '../utils/index.js';
 import type { NotifyDatabaseContext } from './types.js';
 
 export interface Database {
   createModel<S extends object>(ctx: { name: string; initialState: S }): Model<S>;
   createAutoModel(ctx: { name: string }): AutoModel;
+  /**
+   * We use server state key to register the callback.
+   * One server state key can only register one callback.
+   *
+   * This method is not useful for general use case, feel free to ignore this method.
+   */
   subscribe(serverStateKey: object, cb: (ctx: NotifyDatabaseContext) => void): void;
+  /**
+   * This method is not useful for general use case, feel free to ignore this method.
+   */
   getModel(modelName: string): Model<any> | AutoModel | undefined;
 }
 
 export function createDatabase(): Database {
-  const modelRecord: Record<string, Model<any> | AutoModel | undefined> = {};
+  const modelRecord: Record<string, Model<any> | AutoModel> = {};
   const serverStateListenerRecord = new WeakMap<object, (ctx: NotifyDatabaseContext) => void>();
 
   function assertDuplicateName(name: string) {
@@ -20,44 +29,34 @@ export function createDatabase(): Database {
     }
   }
 
-  function subscribe(serverStateKey: object, cb: (ctx: NotifyDatabaseContext) => void) {
-    serverStateListenerRecord.set(serverStateKey, cb);
-  }
-
   function onServerStateChange(ctx: NotifyDatabaseContext) {
     const cb = serverStateListenerRecord.get(ctx.serverStateKey);
     if (!cb) return;
     cb(ctx);
   }
 
-  function createModel<S extends object>({
-    name,
-    initialState,
-  }: {
-    name: string;
-    initialState: S;
-  }) {
-    assertDuplicateName(name);
-    const model = origCreateModel(initialState, ({ serverStateKey, ...ctx }) => {
-      if (serverStateKey) onServerStateChange({ ...ctx, modelName: name, serverStateKey });
-    });
-    modelRecord[name] = model;
-    return model;
-  }
-
-  function createAutoModel({ name }: { name: string }) {
-    assertDuplicateName(name);
-    const model = origCreateAutoModel(({ serverStateKey, ...ctx }) => {
-      if (serverStateKey) onServerStateChange({ ...ctx, modelName: name, serverStateKey });
-    });
-    modelRecord[name] = model;
-    return model;
-  }
-
   return {
-    createModel,
-    createAutoModel,
-    subscribe,
+    createModel({ name, initialState }) {
+      assertDuplicateName(name);
+      const model = origCreateModel(initialState, ({ data, creatorName, ...ctx }) => {
+        if (!data || isUndefined(creatorName)) return;
+        onServerStateChange({ ...ctx, modelName: name, data, creatorName });
+      });
+      modelRecord[name] = model;
+      return model;
+    },
+    createAutoModel({ name }) {
+      assertDuplicateName(name);
+      const model = origCreateAutoModel(({ data, creatorName, ...ctx }) => {
+        if (!data || isUndefined(creatorName)) return;
+        onServerStateChange({ ...ctx, modelName: name, data, creatorName });
+      });
+      modelRecord[name] = model;
+      return model;
+    },
+    subscribe(serverStateKey, cb) {
+      serverStateListenerRecord.set(serverStateKey, cb);
+    },
     getModel(modelName) {
       return modelRecord[modelName];
     },

--- a/packages/daxus/src/lib/model/index.ts
+++ b/packages/daxus/src/lib/model/index.ts
@@ -3,3 +3,4 @@ export * from './Model.js';
 export * from './NormalAccessor.js';
 export * from './types.js';
 export * from './Accessor.js';
+export * from './createDatabase.js';

--- a/packages/daxus/src/lib/model/types.ts
+++ b/packages/daxus/src/lib/model/types.ts
@@ -63,8 +63,8 @@ export interface InfiniteConstructorArgs<S, Arg, Data, E> extends BaseConstructo
 export type NotifyDatabaseContext = {
   serverStateKey: object;
   modelName: string;
-  creatorName?: string;
-  data?: any;
+  creatorName: string;
+  data: any;
   arg?: any;
   pageSize?: number;
   pageIndex?: number;

--- a/packages/daxus/src/lib/model/types.ts
+++ b/packages/daxus/src/lib/model/types.ts
@@ -1,12 +1,9 @@
 import type { Draft } from 'immer';
 
 export interface BaseAction<Arg, D, E> {
+  name: string;
   onError?: (info: { error: E; arg: Arg }) => void;
   onSuccess?: (info: { data: D; arg: Arg }) => void;
-  /**
-   * @internal
-   */
-  prefix?: number;
   /**
    * @internal
    */
@@ -51,7 +48,6 @@ export interface BaseConstructorArgs<S, Arg> {
   notifyModel: () => void;
   onMount: () => void;
   onUnmount: () => void;
-  prefix: number;
   isAuto: boolean;
 }
 
@@ -64,4 +60,25 @@ export interface InfiniteConstructorArgs<S, Arg, Data, E> extends BaseConstructo
   initialPageNum: number;
 }
 
-export type UpdateModelState<S> = (cb: (draft: Draft<S>) => void, serverStateKey?: object) => void;
+export type NotifyDatabaseContext = {
+  modelName: string;
+  creatorName?: string;
+  data?: any;
+  arg?: any;
+  pageSize?: number;
+  pageIndex?: number;
+};
+
+export type UpdateModelStateContext = {
+  serverStateKey?: object;
+  creatorName?: string;
+  data?: any;
+  arg?: any;
+  pageSize?: number;
+  pageIndex?: number;
+};
+
+export type UpdateModelState<S> = (
+  cb: (draft: Draft<S>) => void,
+  context: UpdateModelStateContext
+) => void;

--- a/packages/daxus/src/lib/model/types.ts
+++ b/packages/daxus/src/lib/model/types.ts
@@ -61,6 +61,7 @@ export interface InfiniteConstructorArgs<S, Arg, Data, E> extends BaseConstructo
 }
 
 export type NotifyDatabaseContext = {
+  serverStateKey: object;
   modelName: string;
   creatorName?: string;
   data?: any;

--- a/packages/daxus/src/lib/utils/getKey.ts
+++ b/packages/daxus/src/lib/utils/getKey.ts
@@ -1,5 +1,5 @@
 import { stableHash } from './stableHash.js';
 
-export function getKey(prefix: number, arg: unknown) {
-  return `${prefix}/${stableHash(arg)}`;
+export function getKey(creatorName: string, arg: unknown) {
+  return `${creatorName}/${stableHash(arg)}`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       daxus:
         specifier: workspace:*
         version: link:../../packages/daxus
+      daxus-next:
+        specifier: workspace:*
+        version: link:../../packages/daxus-next
       next:
         specifier: 13.4.12
         version: 13.4.12(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
@@ -174,6 +177,30 @@ importers:
       vitest:
         specifier: ^0.33.0
         version: 0.33.0(jsdom@22.1.0)
+
+  packages/daxus-next:
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.15
+        version: 18.2.16
+      '@types/react-dom':
+        specifier: ^18.2.7
+        version: 18.2.7
+      daxus:
+        specifier: workspace:*
+        version: link:../daxus
+      next:
+        specifier: 13.4.12
+        version: 13.4.12(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
 
 packages:
 
@@ -755,7 +782,6 @@ packages:
 
   /@next/env@13.4.12:
     resolution: {integrity: sha512-RmHanbV21saP/6OEPBJ7yJMuys68cIf8OBBWd7+uj40LdpmswVAwe1uzeuFyUsd6SfeITWT3XnQfn6wULeKwDQ==}
-    dev: false
 
   /@next/swc-darwin-arm64@13.4.12:
     resolution: {integrity: sha512-deUrbCXTMZ6ZhbOoloqecnUeNpUOupi8SE2tx4jPfNS9uyUR9zK4iXBvH65opVcA/9F5I/p8vDXSYbUlbmBjZg==}
@@ -763,7 +789,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-darwin-x64@13.4.12:
@@ -772,7 +797,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-arm64-gnu@13.4.12:
@@ -781,7 +805,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-arm64-musl@13.4.12:
@@ -790,7 +813,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-x64-gnu@13.4.12:
@@ -799,7 +821,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-x64-musl@13.4.12:
@@ -808,7 +829,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-win32-arm64-msvc@13.4.12:
@@ -817,7 +837,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-win32-ia32-msvc@13.4.12:
@@ -826,7 +845,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-win32-x64-msvc@13.4.12:
@@ -835,7 +853,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -878,7 +895,6 @@ packages:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.5.3
-    dev: false
 
   /@testing-library/dom@9.3.0:
     resolution: {integrity: sha512-Dffe68pGwI6WlLRYR2I0piIkyole9cSBH5jGQKCGMRpHW5RHCqAUaqc2Kv0tUyd4dU4DLPKhJIjyKOnjv4tuUw==}
@@ -1493,7 +1509,6 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
-    dev: false
 
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1607,7 +1622,6 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-    dev: false
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2285,7 +2299,6 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-    dev: false
 
   /glob@10.2.6:
     resolution: {integrity: sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==}
@@ -3165,7 +3178,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: false
 
   /node-fetch@2.6.11:
     resolution: {integrity: sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==}
@@ -3407,7 +3419,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: false
 
   /postcss@8.4.27:
     resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
@@ -3473,7 +3484,7 @@ packages:
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
-      react: ^18.2.0 || 18
+      react: ^18.2.0
     dependencies:
       loose-envify: 1.4.0
       react: 18.2.0
@@ -3744,7 +3755,6 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
-    dev: false
 
   /strict-event-emitter@0.2.8:
     resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
@@ -3866,7 +3876,6 @@ packages:
       '@babel/core': 7.22.5
       client-only: 0.0.1
       react: 18.2.0
-    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -4257,7 +4266,6 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
-    dev: false
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -4447,4 +4455,3 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-    dev: false


### PR DESCRIPTION
## Proposed change

This pr refactored the usage of daxus, and support streaming rendering for nextjs.

## Type of change

- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)

## Implementation

I introduced a new api `createDatabase` to create a centralized state manager. Developers now should create model with the database and they need to provide a name to their model and their accessor creator. This may be useful when we want to build a dev tool.

For streaming rendering, we subscribe the database. When the model's state change, it would notify our listener.

## Related Issue

#182 