### PR TITLE
fix(daxus): ignore FetchAbortedError only

### DIFF
--- a/packages/daxus/src/__tests__/Accessor.test.ts
+++ b/packages/daxus/src/__tests__/Accessor.test.ts
@@ -61,4 +61,13 @@ describe('Accessor', () => {
     expect(result1).toEqual([null, createPost(0)]);
     expect(result1).toBe(result2);
   });
+
+  test('should throw the error when the error is not caused by FetchAbortedError', async () => {
+    control.onSuccessMock = () => {
+      throw 1;
+    };
+    const accessor = getPostById(0);
+
+    await expect(async () => accessor.revalidate()).rejects.toThrowError();
+  });
 });

--- a/packages/daxus/src/__tests__/InfiniteAccessor.test.ts
+++ b/packages/daxus/src/__tests__/InfiniteAccessor.test.ts
@@ -103,4 +103,13 @@ describe('InfiniteAccessor', () => {
     const result = await accessor.revalidate({ pageNum: 1 });
     expect(result).toEqual([null, [page0]]);
   });
+
+  test('should throw the error when the error is not caused by FetchAbortedError', async () => {
+    control.onSuccessMock = () => {
+      throw 1;
+    };
+    const accessor = getPostList();
+
+    await expect(async () => accessor.revalidate()).rejects.toThrowError();
+  });
 });

--- a/packages/daxus/src/errors.ts
+++ b/packages/daxus/src/errors.ts
@@ -1,0 +1,5 @@
+export class FetchAbortedError extends Error {
+  constructor(isInfinite: boolean, options?: ErrorOptions) {
+    super(`Is infinite accessor: ${isInfinite}`, options);
+  }
+}


### PR DESCRIPTION
## Proposed change

The user passed function (like syncState) may cause error. We should throw these error, otherwise it would cause the following error:

```
TypeError: Chaining cycle detected for promise
```

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Testing
- [ ] Refactor
- [ ] Chore (tool changes, configuration changes, and changes to things that do not actually go into production at all)

## Implementation

## Related Issue
