### PR TITLE
feat(daxus): support meta for pagination

### DIFF
--- a/packages/daxus/src/__tests__/InfiniteAccessor.test.ts
+++ b/packages/daxus/src/__tests__/InfiniteAccessor.test.ts
@@ -112,19 +112,4 @@ describe('InfiniteAccessor', () => {
 
     await expect(async () => accessor.revalidate()).rejects.toThrowError();
   });
-
-  test('should correctly update the reachEnd', async () => {
-    control.fetchDataMock = () => {
-      return null;
-    };
-    const accessor = getPostList();
-    await accessor.revalidate();
-
-    expect(accessor.isEnd()).toBe(true);
-
-    control.fetchDataMock = undefined;
-    await accessor.revalidate();
-
-    expect(accessor.isEnd()).toBe(false);
-  });
 });

--- a/packages/daxus/src/__tests__/createPaginationState.test.ts
+++ b/packages/daxus/src/__tests__/createPaginationState.test.ts
@@ -37,26 +37,53 @@ describe('createPaginationState', () => {
 
   test('should correctly create/read/update/delete pagination', () => {
     const key = '';
-    let state = createPaginationState<Post>();
+    let state = createPaginationState<Post, Post, { isEnded?: boolean }>();
 
     state = produce(state, draft => {
       draft.replacePagination(key, [createPost(1)]);
     });
-    expect(state.readPaginationData(key)).toEqual([createPost(1)]);
+    expect(state.readPagination(key)).toEqual({
+      data: [createPost(1)],
+      ids: ['1'],
+      meta: {},
+    });
 
+    // append
     state = produce(state, draft => {
       draft.appendPagination(key, [createPost(2)]);
     });
-    expect(state.readPaginationData(key)).toEqual([createPost(1), createPost(2)]);
+    expect(state.readPagination(key)).toEqual({
+      data: [createPost(1), createPost(2)],
+      ids: ['1', '2'],
+      meta: {},
+    });
 
+    // prepend
     state = produce(state, draft => {
       draft.prependPagination(key, [createPost(3)]);
     });
-    expect(state.readPaginationData(key)).toEqual([createPost(3), createPost(1), createPost(2)]);
+    expect(state.readPagination(key)).toEqual({
+      data: [createPost(3), createPost(1), createPost(2)],
+      ids: ['3', '1', '2'],
+      meta: {},
+    });
 
+    // sorting
     state = produce(state, draft => {
       draft.sortPagination(key, (a, b) => +a.id - +b.id);
     });
-    expect(state.readPaginationData(key)).toEqual([createPost(1), createPost(2), createPost(3)]);
+    expect(state.readPagination(key)).toEqual({
+      data: [createPost(1), createPost(2), createPost(3)],
+      ids: ['1', '2', '3'],
+      meta: {},
+    });
+
+    // update meta
+    state = produce(state, draft => {
+      draft.updatePagination(key, { meta: { isEnded: true } });
+    });
+    expect(state.readPagination(key).meta).toEqual({
+      isEnded: true,
+    });
   });
 });

--- a/packages/daxus/src/model/InfiniteAccessor.ts
+++ b/packages/daxus/src/model/InfiniteAccessor.ts
@@ -23,7 +23,6 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
   private rejectFetching: (() => void) | null = null;
   private currentTask: Task = 'idle';
   private initialPageNum: number;
-  private reachEnd = false;
 
   /**
    * @internal
@@ -58,14 +57,6 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
     this.action = action;
     this.updateState = updateState;
     this.initialPageNum = initialPageNum;
-  }
-
-  /**
-   * Whether the pagination has fetched the last page.
-   * @returns
-   */
-  isEnd(): boolean {
-    return this.reachEnd;
   }
 
   /**
@@ -155,7 +146,6 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
         break;
       }
       if (!data) {
-        this.reachEnd = true;
         break;
       }
       previousData = data;
@@ -185,7 +175,6 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
       }
     }
 
-    this.reachEnd = false;
     this.currentTask = task;
     this.rejectFetching?.();
     const fetchPromise = (async () => {


### PR DESCRIPTION
## Proposed change

Whether the pagination is ended should be determined by the users. As a result, the pagination should add a field to record it. The users may want to record something else, so I add a field to allow user to customize it.

## Type of change

- [x] New feature (which adds functionality to an existing integration)
