### PR TITLE
fix(daxus): record data to fetch page correctly

### DIFF
--- a/packages/daxus/src/model/InfiniteAccessor.ts
+++ b/packages/daxus/src/model/InfiniteAccessor.ts
@@ -14,7 +14,7 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
 > {
   protected action: InfiniteAction<S, Arg, Data, E>;
   private updateState: UpdateModelState<S>;
-  private data: Data[] = [];
+  private data: Data[];
   /**
    * This property is used to reject ant ongoing fetching.
    * It may be invoked when there is a revalidation executing,
@@ -22,7 +22,6 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
    */
   private rejectFetching: (() => void) | null = null;
   private currentTask: Task = 'idle';
-  private initialPageNum: number;
 
   /**
    * @internal
@@ -36,11 +35,11 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
     notifyModel,
     onMount,
     onUnmount,
-    initialPageNum,
     isAuto,
     setStaleTime,
     getIsStale,
     creatorName,
+    data,
   }: InfiniteConstructorArgs<S, Arg, Data, E>) {
     super({
       getState,
@@ -56,7 +55,14 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
     });
     this.action = action;
     this.updateState = updateState;
-    this.initialPageNum = initialPageNum;
+    this.data = data;
+  }
+
+  /**
+   * @internal
+   */
+  getData(): Data[] {
+    return this.data;
   }
 
   /**
@@ -70,7 +76,7 @@ export class InfiniteAccessor<S, Arg = any, Data = any, E = unknown> extends Bas
    * {@inheritDoc BaseAccessor.revalidate}
    */
   revalidate = (context: RevalidateContext = {}) => {
-    const pageNum = context.pageNum || this.getPageNum() || this.initialPageNum || 1;
+    const pageNum = context.pageNum || this.getPageNum() || 1;
     return this.fetch({ pageNum, pageIndex: 0, task: 'validate', ...context });
   };
 

--- a/packages/daxus/src/model/createModel.ts
+++ b/packages/daxus/src/model/createModel.ts
@@ -83,9 +83,9 @@ export function createModel<S extends object>({
   const isStaleRecord = {} as Record<string, boolean>;
 
   /**
-   * instead of recording the whole data, we only record the pages number to save the memory usage
+   * Record the fetched data of the infinite accessors.
    */
-  const infiniteAccessorPageNumRecord = {} as Record<string, number | undefined>;
+  const infiniteAccessorDataRecord = {} as Record<string, any[]>;
 
   function assertDuplicateName(name: string) {
     if (objectKeys(creatorRecord).includes(name)) {
@@ -253,7 +253,7 @@ export function createModel<S extends object>({
         if (!accessor) return;
         // Don't delete the accessor if it is mounted.
         if (accessor.isMounted()) return;
-        infiniteAccessorPageNumRecord[key] = accessor.getPageNum();
+        infiniteAccessorDataRecord[key] = accessor.getData();
         delete accessorRecord[key];
       };
 
@@ -274,9 +274,9 @@ export function createModel<S extends object>({
         updateState,
         onMount,
         onUnmount,
-        initialPageNum: infiniteAccessorPageNumRecord[key] ?? 1,
         isAuto: action.isAuto ?? false,
         setStaleTime: compositeSetStale(key),
+        data: infiniteAccessorDataRecord[key] ?? [],
         getIsStale() {
           return isStaleRecord[key] ?? false;
         },

--- a/packages/daxus/src/model/types.ts
+++ b/packages/daxus/src/model/types.ts
@@ -58,7 +58,7 @@ export interface ConstructorArgs<S, Arg, Data, E> extends BaseConstructorArgs<S,
 
 export interface InfiniteConstructorArgs<S, Arg, Data, E> extends BaseConstructorArgs<S, Arg> {
   action: InfiniteAction<S, Arg, Data, E>;
-  initialPageNum: number;
+  data: Data[];
 }
 
 export type NotifyDatabaseContext = {


### PR DESCRIPTION
## Proposed change

When fetching the next page, the infinite accessor would need the data to get the previous page. As a result, we need to record the data instead of the page number.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
